### PR TITLE
Improvements for DisplayRecipe functionality

### DIFF
--- a/src/main/java/app/DisplayRecipeAppBuilder.java
+++ b/src/main/java/app/DisplayRecipeAppBuilder.java
@@ -40,7 +40,6 @@ public class DisplayRecipeAppBuilder {
      * controller.
      *
      * @return this builder
-     * @throws RuntimeException if this method is called before addDisplayRecipeView
      */
     public DisplayRecipeAppBuilder addDisplayRecipeUseCase() {
         final DisplayRecipeOutputBoundary recipeOutputBoundary = new DisplayRecipePresenter(viewManagerModel, displayRecipeViewModel);
@@ -67,7 +66,7 @@ public class DisplayRecipeAppBuilder {
     }
 
     /**
-     * Builds the application.
+     * Builds the Display Recipe view into a JFrame.
      *
      * @return the JFrame for the application
      */
@@ -83,5 +82,9 @@ public class DisplayRecipeAppBuilder {
         frame.add(displayRecipeView);
 
         return frame;
+    }
+
+    public DisplayRecipeView getDisplayRecipeView() {
+        return displayRecipeView;
     }
 }

--- a/src/main/java/app/DisplayRecipeAppBuilder.java
+++ b/src/main/java/app/DisplayRecipeAppBuilder.java
@@ -1,0 +1,87 @@
+package app;
+
+import javax.swing.JFrame;
+import javax.swing.WindowConstants;
+
+import interface_adapter.ViewManagerModel;
+import interface_adapter.display_recipe.DisplayRecipeController;
+import interface_adapter.display_recipe.DisplayRecipePresenter;
+import interface_adapter.display_recipe.DisplayRecipeViewModel;
+import use_case.display_recipe.DisplayRecipeDataAccessInterface;
+import use_case.display_recipe.DisplayRecipeInteractor;
+import use_case.display_recipe.DisplayRecipeOutputBoundary;
+import view.DisplayRecipeView;
+
+/**
+ * Builder for the Display Recipe Application.
+ */
+public class DisplayRecipeAppBuilder {
+    public static final int HEIGHT = 800;
+    public static final int WIDTH = 1200;
+    private DisplayRecipeDataAccessInterface displayRecipeDAO;
+    private DisplayRecipeViewModel displayRecipeViewModel = new DisplayRecipeViewModel();
+    private DisplayRecipeView displayRecipeView;
+    private DisplayRecipeInteractor displayRecipeInteractor;
+    private ViewManagerModel viewManagerModel;
+
+    /**
+     * Sets the RecipeDAO to be used in this application.
+     *
+     * @param recipeDataAccess the DAO to use
+     * @return this builder
+     */
+    public DisplayRecipeAppBuilder addDisplayRecipeDAO(DisplayRecipeDataAccessInterface recipeDataAccess) {
+        displayRecipeDAO = recipeDataAccess;
+        return this;
+    }
+
+    /**
+     * Creates the objects for the Display Recipe Use Case and connects the DisplayRecipeView to its
+     * controller.
+     *
+     * @return this builder
+     * @throws RuntimeException if this method is called before addDisplayRecipeView
+     */
+    public DisplayRecipeAppBuilder addDisplayRecipeUseCase() {
+        final DisplayRecipeOutputBoundary recipeOutputBoundary = new DisplayRecipePresenter(viewManagerModel, displayRecipeViewModel);
+        displayRecipeInteractor = new DisplayRecipeInteractor(recipeOutputBoundary, displayRecipeDAO);
+
+        final DisplayRecipeController controller = new DisplayRecipeController(displayRecipeInteractor);
+        if (displayRecipeView == null) {
+            throw new RuntimeException("addDisplayRecipeView must be called before addDisplayRecipeUseCase");
+        }
+        displayRecipeView.setRecipeController(controller);
+        return this;
+    }
+
+    /**
+     * Creates the DisplayRecipeView and underlying DisplayRecipeViewModel.
+     *
+     * @return this builder
+     */
+    public DisplayRecipeAppBuilder addDisplayRecipeView() {
+        viewManagerModel = new ViewManagerModel();
+        displayRecipeViewModel = new DisplayRecipeViewModel();
+        displayRecipeView = new DisplayRecipeView(displayRecipeViewModel);
+        return this;
+    }
+
+    /**
+     * Builds the application.
+     *
+     * @return the JFrame for the application
+     */
+    public JFrame build() {
+        final JFrame frame = new JFrame();
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        frame.setTitle("Recipe Display Application");
+        frame.setSize(WIDTH, HEIGHT);
+
+        frame.setLocationRelativeTo(null);
+        frame.setResizable(false);
+
+        frame.add(displayRecipeView);
+
+        return frame;
+    }
+}

--- a/src/main/java/app/SearchRecipeAppBuilder.java
+++ b/src/main/java/app/SearchRecipeAppBuilder.java
@@ -20,7 +20,7 @@ public class SearchRecipeAppBuilder {
     public static final int WIDTH = 1200;
     private SearchRecipeDataAccessInterface searchrecipeDAO;
     private SearchRecipeViewModel searchrecipeViewModel = new SearchRecipeViewModel();
-    private SearchRecipeView searchrecipeView;
+    private SearchRecipeView searchRecipeView;
     private SearchRecipeInteractor searchrecipeInteractor;
     private ViewManagerModel viewManagerModel;
 
@@ -47,10 +47,10 @@ public class SearchRecipeAppBuilder {
         searchrecipeInteractor = new SearchRecipeInteractor(searchrecipeDAO, recipeOutputBoundary);
 
         final SearchRecipeController controller = new SearchRecipeController(searchrecipeInteractor);
-        if (searchrecipeView == null) {
+        if (searchRecipeView == null) {
             throw new RuntimeException("addRecipeView must be called before addRecipeUseCase");
         }
-        searchrecipeView.setRecipeController(controller);
+        searchRecipeView.setRecipeController(controller);
         return this;
     }
 
@@ -62,7 +62,7 @@ public class SearchRecipeAppBuilder {
     public SearchRecipeAppBuilder addSearchRecipeView() {
         viewManagerModel = new ViewManagerModel();
         searchrecipeViewModel = new SearchRecipeViewModel();
-        searchrecipeView = new SearchRecipeView(searchrecipeViewModel);
+        searchRecipeView = new SearchRecipeView(searchrecipeViewModel);
         return this;
     }
 
@@ -80,8 +80,12 @@ public class SearchRecipeAppBuilder {
         frame.setLocationRelativeTo(null);
         frame.setResizable(false);
 
-        frame.add(searchrecipeView);
+        frame.add(searchRecipeView);
 
         return frame;
+    }
+
+    public SearchRecipeView getSearchRecipeView() {
+        return searchRecipeView;
     }
 }

--- a/src/main/java/app/SearchRecipeApplication.java
+++ b/src/main/java/app/SearchRecipeApplication.java
@@ -6,9 +6,6 @@ import use_case.display_recipe.DisplayRecipeDataAccessInterface;
 import javax.swing.JFrame;
 import java.awt.CardLayout;
 
-/**
- * Builder for the Search Recipe Application.
- */
 public class SearchRecipeApplication {
 
     public static void main(String[] args) {
@@ -30,8 +27,8 @@ public class SearchRecipeApplication {
 
         final SearchRecipeAppBuilder searchBuilder = new SearchRecipeAppBuilder();
         searchBuilder.addSearchRecipeDAO(searchRecipeDAO)
-               .addSearchRecipeView()
-               .addSearchRecipeUseCase().build().setVisible(true);
+                .addSearchRecipeView()
+                .addSearchRecipeUseCase();
 
         final DisplayRecipeAppBuilder displayBuilder = new DisplayRecipeAppBuilder();
         displayBuilder.addDisplayRecipeDAO(displayRecipeDAO)
@@ -44,6 +41,15 @@ public class SearchRecipeApplication {
 
         // Set the initial view to the search view
         cardLayout.show(frame.getContentPane(), "searchView");
+
+        // Event listener to switch to Display view when a recipe is clicked
+        searchBuilder.getSearchRecipeView().addRecipeClickListener(recipeId -> {
+            displayBuilder.getDisplayRecipeView().loadRecipeDetails(recipeId);
+            cardLayout.show(frame.getContentPane(), "displayView");
+        });
+
+        // Optionally add a back button in DisplayRecipeView to go back to SearchRecipeView
+        displayBuilder.getDisplayRecipeView().addBackButtonListener(() -> cardLayout.show(frame.getContentPane(), "searchView"));
 
         // Show the frame
         frame.setVisible(true);

--- a/src/main/java/app/SearchRecipeApplication.java
+++ b/src/main/java/app/SearchRecipeApplication.java
@@ -2,6 +2,9 @@ package app;
 
 import data_access.RecipeDataAccessObject;
 import use_case.search_recipe.SearchRecipeDataAccessInterface;
+import use_case.display_recipe.DisplayRecipeDataAccessInterface;
+import javax.swing.JFrame;
+import java.awt.CardLayout;
 
 /**
  * Builder for the Search Recipe Application.
@@ -11,10 +14,38 @@ public class SearchRecipeApplication {
     public static void main(String[] args) {
 
         final SearchRecipeDataAccessInterface searchRecipeDAO = new RecipeDataAccessObject();
+        final DisplayRecipeDataAccessInterface displayRecipeDAO = new RecipeDataAccessObject();
 
-        final SearchRecipeAppBuilder builder = new SearchRecipeAppBuilder();
-        builder.addSearchRecipeDAO(searchRecipeDAO)
+        // Set up a frame with a CardLayout to handle view switching
+        final JFrame frame = new JFrame();
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setTitle("Recipe Application");
+        frame.setSize(1200, 800);
+        frame.setLocationRelativeTo(null);
+        frame.setResizable(false);
+
+        // Use CardLayout to manage switching between views
+        CardLayout cardLayout = new CardLayout();
+        frame.setLayout(cardLayout);
+
+        final SearchRecipeAppBuilder searchBuilder = new SearchRecipeAppBuilder();
+        searchBuilder.addSearchRecipeDAO(searchRecipeDAO)
                .addSearchRecipeView()
                .addSearchRecipeUseCase().build().setVisible(true);
+
+        final DisplayRecipeAppBuilder displayBuilder = new DisplayRecipeAppBuilder();
+        displayBuilder.addDisplayRecipeDAO(displayRecipeDAO)
+                .addDisplayRecipeView()
+                .addDisplayRecipeUseCase();
+
+        // Add both views to the frame's CardLayout
+        frame.add(searchBuilder.build().getContentPane(), "searchView");
+        frame.add(displayBuilder.build().getContentPane(), "displayView");
+
+        // Set the initial view to the search view
+        cardLayout.show(frame.getContentPane(), "searchView");
+
+        // Show the frame
+        frame.setVisible(true);
     }
 }

--- a/src/main/java/data_access/RecipeDataAccessObject.java
+++ b/src/main/java/data_access/RecipeDataAccessObject.java
@@ -21,7 +21,7 @@ import use_case.display_recipe.DisplayRecipeDataAccessInterface;
  * Implements both SearchRecipeDataAccessInterface and DisplayRecipeDataAccessInterface.
  */
 public class RecipeDataAccessObject implements SearchRecipeDataAccessInterface, DisplayRecipeDataAccessInterface {
-    private static final String API_KEY = "8c57d019b3ec4934bad61b670ecc45a9";
+    private static final String API_KEY = "60a6599269fc4a1e9bdfe92aaf1b3984";
     private static final String BASE_SEARCH_URL = "https://api.spoonacular.com/recipes/complexSearch";
     private static final String BASE_DETAILS_URL = "https://api.spoonacular.com/recipes/%d/information?&apiKey=%s&includeNutrition=true";
 

--- a/src/main/java/data_access/RecipeDataAccessObject.java
+++ b/src/main/java/data_access/RecipeDataAccessObject.java
@@ -21,7 +21,7 @@ import use_case.display_recipe.DisplayRecipeDataAccessInterface;
  * Implements both SearchRecipeDataAccessInterface and DisplayRecipeDataAccessInterface.
  */
 public class RecipeDataAccessObject implements SearchRecipeDataAccessInterface, DisplayRecipeDataAccessInterface {
-    private static final String API_KEY = "60a6599269fc4a1e9bdfe92aaf1b3984";
+    private static final String API_KEY = "e6a971c78acb49dcbb4e5b324c05d436";
     private static final String BASE_SEARCH_URL = "https://api.spoonacular.com/recipes/complexSearch";
     private static final String BASE_DETAILS_URL = "https://api.spoonacular.com/recipes/%d/information?&apiKey=%s&includeNutrition=true";
 

--- a/src/main/java/entity/CommonIngredient.java
+++ b/src/main/java/entity/CommonIngredient.java
@@ -35,4 +35,10 @@ public class CommonIngredient implements Ingredient {
     public String getUnit() {
         return unit;
     }
+
+    @Override
+    public String toString() {
+        return getName() + " - " + getAmount() + " " + getUnit();
+    }
+
 }

--- a/src/main/java/entity/CommonInstruction.java
+++ b/src/main/java/entity/CommonInstruction.java
@@ -58,4 +58,7 @@ public class CommonInstruction implements Instruction {
     public void setDescription(String description) {
         this.description = description;
     }
+
+    @Override
+    public String toString() { return "Step " + getNumber() + ": " + getDescription(); }
 }

--- a/src/main/java/interface_adapter/display_recipe/DisplayRecipeController.java
+++ b/src/main/java/interface_adapter/display_recipe/DisplayRecipeController.java
@@ -19,7 +19,7 @@ public class DisplayRecipeController {
      * @param RecipeId the unique identifier of the recipe to display
      */
     public void execute(int RecipeId) {
-        System.out.println(RecipeId);
+        System.out.println("DisplayRecipeController received recipeId: " + RecipeId);
         // 1. Instantiate the `DisplayRecipeInputData`, which should contain the recipe ID.
         final DisplayRecipeInputData inputData = new DisplayRecipeInputData(RecipeId);
         // 2. Tell the Interactor to execute.

--- a/src/main/java/interface_adapter/display_recipe/DisplayRecipePresenter.java
+++ b/src/main/java/interface_adapter/display_recipe/DisplayRecipePresenter.java
@@ -3,6 +3,10 @@ package interface_adapter.display_recipe;
 import interface_adapter.ViewManagerModel;
 import use_case.display_recipe.DisplayRecipeOutputBoundary;
 import use_case.display_recipe.DisplayRecipeOutputData;
+import entity.Ingredient;
+import entity.Instruction;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * The Presenter for the Display Recipe Use Case.
@@ -16,7 +20,7 @@ public class DisplayRecipePresenter implements DisplayRecipeOutputBoundary {
     /**
      * Constructs a DisplayRecipePresenter with the specified ViewManagerModel and DisplayRecipeViewModel.
      *
-     * @param viewManager          the view manager model to handle view switching
+     * @param viewManager            the view manager model to handle view switching
      * @param displayRecipeViewModel the view model to update with recipe data
      */
     public DisplayRecipePresenter(ViewManagerModel viewManager, DisplayRecipeViewModel displayRecipeViewModel) {
@@ -32,14 +36,27 @@ public class DisplayRecipePresenter implements DisplayRecipeOutputBoundary {
     @Override
     public void prepareSuccessView(DisplayRecipeOutputData outputData) {
         // Create a new DisplayRecipeState and populate it with data from outputData
-        final DisplayRecipeState displayRecipeState = new DisplayRecipeState();
+        DisplayRecipeState displayRecipeState = new DisplayRecipeState();
 
-        displayRecipeState.setRecipeName(outputData.getTitle());
-        displayRecipeState.setIngredients(outputData.getIngredients().toString());
-        displayRecipeState.setInstructions(outputData.getInstructions().toString());
+        displayRecipeState.setTitle(outputData.getTitle());
+
+        // Convert List<Ingredient> to List<String> for display
+        List<String> ingredientStrings = outputData.getIngredients().stream()
+                .map(Ingredient::toString)  // Assuming Ingredient has a meaningful toString() method
+                .collect(Collectors.toList());
+        displayRecipeState.setIngredients(ingredientStrings);
+
+        // Convert List<Instruction> to List<String> for display
+        List<String> instructionStrings = outputData.getInstructions().stream()
+                .map(Instruction::toString)  // Assuming Instruction has a meaningful toString() method
+                .collect(Collectors.toList());
+        displayRecipeState.setInstructions(instructionStrings);
+
+        displayRecipeState.setImageUrl(outputData.getImage());
 
         // Update the DisplayRecipeViewModel with the new state
         displayRecipeViewModel.setState(displayRecipeState);
+        displayRecipeViewModel.firePropertyChanged("state");  // Notify listeners
 
         // Update viewManager with the new view name
         viewManager.setState(displayRecipeViewModel.getViewName());
@@ -50,10 +67,18 @@ public class DisplayRecipePresenter implements DisplayRecipeOutputBoundary {
      *
      * @param errorMessage the error message explaining the failure
      */
+//    @Override
+//    public void prepareFailView(String errorMessage) {
+//        final DisplayRecipeState displayRecipeState = displayRecipeViewModel.getState();
+//        displayRecipeState.setDisplayError(errorMessage);
+//        displayRecipeViewModel.firePropertyChanged();
+//    }
+//}
     @Override
     public void prepareFailView(String errorMessage) {
-        final DisplayRecipeState displayRecipeState = displayRecipeViewModel.getState();
-        displayRecipeState.setDisplayError(errorMessage);
-        displayRecipeViewModel.firePropertyChanged();
+        DisplayRecipeState errorState = new DisplayRecipeState();
+        errorState.setDisplayError(errorMessage);
+        displayRecipeViewModel.setState(errorState);
+        displayRecipeViewModel.firePropertyChanged("state");  // Notify listeners of the error state
     }
 }

--- a/src/main/java/interface_adapter/display_recipe/DisplayRecipePresenter.java
+++ b/src/main/java/interface_adapter/display_recipe/DisplayRecipePresenter.java
@@ -3,82 +3,50 @@ package interface_adapter.display_recipe;
 import interface_adapter.ViewManagerModel;
 import use_case.display_recipe.DisplayRecipeOutputBoundary;
 import use_case.display_recipe.DisplayRecipeOutputData;
-import entity.Ingredient;
-import entity.Instruction;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
 /**
  * The Presenter for the Display Recipe Use Case.
- * Implements the DisplayRecipeOutputBoundary to prepare data for the view.
  */
 public class DisplayRecipePresenter implements DisplayRecipeOutputBoundary {
 
     private final ViewManagerModel viewManager;
     private final DisplayRecipeViewModel displayRecipeViewModel;
 
-    /**
-     * Constructs a DisplayRecipePresenter with the specified ViewManagerModel and DisplayRecipeViewModel.
-     *
-     * @param viewManager            the view manager model to handle view switching
-     * @param displayRecipeViewModel the view model to update with recipe data
-     */
     public DisplayRecipePresenter(ViewManagerModel viewManager, DisplayRecipeViewModel displayRecipeViewModel) {
         this.viewManager = viewManager;
         this.displayRecipeViewModel = displayRecipeViewModel;
     }
 
-    /**
-     * Prepares the success view with the provided DisplayRecipeOutputData.
-     *
-     * @param outputData the output data containing recipe details
-     */
     @Override
     public void prepareSuccessView(DisplayRecipeOutputData outputData) {
-        // Create a new DisplayRecipeState and populate it with data from outputData
-        DisplayRecipeState displayRecipeState = new DisplayRecipeState();
+        System.out.println("DisplayRecipePresenter updating ViewModel with recipe details");
 
-        displayRecipeState.setTitle(outputData.getTitle());
-
-        // Convert List<Ingredient> to List<String> for display
+        // Convert ingredients and instructions to display-friendly strings
         List<String> ingredientStrings = outputData.getIngredients().stream()
-                .map(Ingredient::toString)  // Assuming Ingredient has a meaningful toString() method
+                .map(ingredient -> ingredient.getName() + " - " + ingredient.getAmount() + " " + ingredient.getUnit())
                 .collect(Collectors.toList());
-        displayRecipeState.setIngredients(ingredientStrings);
 
-        // Convert List<Instruction> to List<String> for display
         List<String> instructionStrings = outputData.getInstructions().stream()
-                .map(Instruction::toString)  // Assuming Instruction has a meaningful toString() method
+                .map(instruction -> "Step " + instruction.getNumber() + ": " + instruction.getDescription())
                 .collect(Collectors.toList());
-        displayRecipeState.setInstructions(instructionStrings);
 
-        displayRecipeState.setImageUrl(outputData.getImage());
+        // Update ViewModel
+        displayRecipeViewModel.updateRecipeDetails(
+                outputData.getTitle(),
+                outputData.getImage(),
+                ingredientStrings,
+                instructionStrings
+        );
 
-        // Update the DisplayRecipeViewModel with the new state
-        displayRecipeViewModel.setState(displayRecipeState);
-        displayRecipeViewModel.firePropertyChanged("state");  // Notify listeners
-
-        // Update viewManager with the new view name
+        // Switch the view state
         viewManager.setState(displayRecipeViewModel.getViewName());
     }
 
-    /**
-     * Prepares the failure view with the provided error message.
-     *
-     * @param errorMessage the error message explaining the failure
-     */
-//    @Override
-//    public void prepareFailView(String errorMessage) {
-//        final DisplayRecipeState displayRecipeState = displayRecipeViewModel.getState();
-//        displayRecipeState.setDisplayError(errorMessage);
-//        displayRecipeViewModel.firePropertyChanged();
-//    }
-//}
     @Override
     public void prepareFailView(String errorMessage) {
-        DisplayRecipeState errorState = new DisplayRecipeState();
-        errorState.setDisplayError(errorMessage);
-        displayRecipeViewModel.setState(errorState);
-        displayRecipeViewModel.firePropertyChanged("state");  // Notify listeners of the error state
+        displayRecipeViewModel.updateWithError(errorMessage);
     }
 }

--- a/src/main/java/interface_adapter/display_recipe/DisplayRecipeState.java
+++ b/src/main/java/interface_adapter/display_recipe/DisplayRecipeState.java
@@ -1,44 +1,75 @@
 package interface_adapter.display_recipe;
 
+import java.util.List;
+
 /**
- * The state for the DisplayRecipe ViewModel.
+ * The state for displaying a recipe.
+ * Holds only the essential fields needed for the recipe display view.
  */
 public class DisplayRecipeState {
-    private String recipeName = "";
-    private String ingredients = "";
-    private String instructions = "";
+    private String title;
+    private String imageUrl;
+    private List<String> ingredients;
+    private List<String> instructions;
     private String displayError;
 
-    public String getRecipeName() {
-        return recipeName;
+    // Getters and Setters
+    public String getTitle() {
+        return title;
     }
 
-    public String getIngredients() {
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public List<String> getIngredients() {
         return ingredients;
     }
 
-    public String getInstructions() {
+    public void setIngredients(List<String> ingredients) {
+        this.ingredients = ingredients;
+    }
+
+    public List<String> getInstructions() {
         return instructions;
+    }
+
+    public void setInstructions(List<String> instructions) {
+        this.instructions = instructions;
     }
 
     public String getDisplayError() {
         return displayError;
     }
 
-    public void setRecipeName(String recipeName) {
-        this.recipeName = recipeName;
-    }
-
-    public void setIngredients(String ingredients) {
-        this.ingredients = ingredients;
-    }
-
-    public void setInstructions(String instructions) {
-        this.instructions = instructions;
-    }
-
     public void setDisplayError(String displayError) {
         this.displayError = displayError;
     }
-}
 
+    /**
+     * Checks if the state represents an error state.
+     * @return true if there is an error message, false otherwise.
+     */
+    public boolean isError() {
+        return displayError != null && !displayError.isEmpty();
+    }
+
+    /**
+     * Resets the state to clear all fields.
+     */
+    public void reset() {
+        this.title = null;
+        this.imageUrl = null;
+        this.ingredients = null;
+        this.instructions = null;
+        this.displayError = null;
+    }
+}

--- a/src/main/java/interface_adapter/display_recipe/DisplayRecipeViewModel.java
+++ b/src/main/java/interface_adapter/display_recipe/DisplayRecipeViewModel.java
@@ -1,17 +1,45 @@
 package interface_adapter.display_recipe;
 
 import interface_adapter.ViewModel;
+import java.util.List;
 
 /**
- * The ViewModel for the DisplayRecipe View.
+ * The ViewModel for displaying recipe details.
  */
 public class DisplayRecipeViewModel extends ViewModel<DisplayRecipeState> {
 
-    /**
-     * Initializes the DisplayRecipeViewModel with the default state.
-     */
     public DisplayRecipeViewModel() {
         super("display recipe");
         setState(new DisplayRecipeState());
+    }
+
+    /**
+     * Updates the ViewModel state with the recipe details.
+     *
+     * @param title The title of the recipe.
+     * @param imageUrl The URL of the recipe image.
+     * @param ingredients The list of ingredients for the recipe.
+     * @param instructions The list of instructions for the recipe.
+     */
+    public void updateRecipeDetails(String title, String imageUrl, List<String> ingredients, List<String> instructions) {
+        DisplayRecipeState newState = new DisplayRecipeState();
+        newState.setTitle(title);
+        newState.setImageUrl(imageUrl);
+        newState.setIngredients(ingredients);
+        newState.setInstructions(instructions);
+        setState(newState);  // Set the new state
+        firePropertyChanged("state");  // Notify listeners of the update
+    }
+
+    /**
+     * Updates the ViewModel with an error message.
+     *
+     * @param errorMessage The error message to display.
+     */
+    public void updateWithError(String errorMessage) {
+        DisplayRecipeState errorState = new DisplayRecipeState();
+        errorState.setDisplayError(errorMessage);
+        setState(errorState);  // Set the error state
+        firePropertyChanged("state");  // Notify listeners of the update
     }
 }

--- a/src/main/java/interface_adapter/display_recipe/DisplayRecipeViewModel.java
+++ b/src/main/java/interface_adapter/display_recipe/DisplayRecipeViewModel.java
@@ -6,40 +6,38 @@ import java.util.List;
 /**
  * The ViewModel for displaying recipe details.
  */
-public class DisplayRecipeViewModel extends ViewModel<DisplayRecipeState> {
+public class DisplayRecipeViewModel extends ViewModel {
+
+    private String title;
+    private String imageUrl;
+    private List<String> ingredients;
+    private List<String> instructions;
+    private String errorMessage;
 
     public DisplayRecipeViewModel() {
         super("display recipe");
-        setState(new DisplayRecipeState());
     }
 
-    /**
-     * Updates the ViewModel state with the recipe details.
-     *
-     * @param title The title of the recipe.
-     * @param imageUrl The URL of the recipe image.
-     * @param ingredients The list of ingredients for the recipe.
-     * @param instructions The list of instructions for the recipe.
-     */
     public void updateRecipeDetails(String title, String imageUrl, List<String> ingredients, List<String> instructions) {
-        DisplayRecipeState newState = new DisplayRecipeState();
-        newState.setTitle(title);
-        newState.setImageUrl(imageUrl);
-        newState.setIngredients(ingredients);
-        newState.setInstructions(instructions);
-        setState(newState);  // Set the new state
-        firePropertyChanged("state");  // Notify listeners of the update
+        this.title = title;
+        this.imageUrl = imageUrl;
+        this.ingredients = ingredients;
+        this.instructions = instructions;
+        this.errorMessage = null;  // Clear any previous error message
+
+        firePropertyChanged("state");
     }
 
-    /**
-     * Updates the ViewModel with an error message.
-     *
-     * @param errorMessage The error message to display.
-     */
     public void updateWithError(String errorMessage) {
-        DisplayRecipeState errorState = new DisplayRecipeState();
-        errorState.setDisplayError(errorMessage);
-        setState(errorState);  // Set the error state
-        firePropertyChanged("state");  // Notify listeners of the update
+        this.errorMessage = errorMessage;
+
+        firePropertyChanged("state");
     }
+
+    // Getters for DisplayRecipeView to retrieve updated values
+    public String getTitle() { return title; }
+    public String getImageUrl() { return imageUrl; }
+    public List<String> getIngredients() { return ingredients; }
+    public List<String> getInstructions() { return instructions; }
+    public String getErrorMessage() { return errorMessage; }
 }

--- a/src/main/java/use_case/display_recipe/DisplayRecipeInteractor.java
+++ b/src/main/java/use_case/display_recipe/DisplayRecipeInteractor.java
@@ -32,6 +32,7 @@ public class DisplayRecipeInteractor implements DisplayRecipeInputBoundary {
      */
     @Override
     public void execute(DisplayRecipeInputData inputData) {
+        System.out.println("DisplayRecipeInteractor executing with recipeId: " + inputData.getRecipeId());
         try {
             // Retrieve the recipe using the data access interface
             Recipe recipe = dataAccess.getRecipeById(inputData.getRecipeId());

--- a/src/main/java/view/SearchRecipeView.java
+++ b/src/main/java/view/SearchRecipeView.java
@@ -23,6 +23,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.net.URL;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * The View for the Search Recipe Use Case.
@@ -39,6 +40,7 @@ public class SearchRecipeView extends JPanel {
 
     // Adjust the roundness
     private final int cornerRadius = 50;
+    private Consumer<Integer> recipeClickListener;
 
     /**
      * Constructor for the SearchRecipeView.
@@ -284,6 +286,10 @@ public class SearchRecipeView extends JPanel {
         displayRecipes(recipes);
     }
 
+    public void addRecipeClickListener(Consumer<Integer> listener) {
+        this.recipeClickListener = listener;
+    }
+
     private void displayRecipes(List<SearchRecipeOutputData> recipes) {
         // Remove all existing components from the center panel
         centerPanel.removeAll();
@@ -374,7 +380,10 @@ public class SearchRecipeView extends JPanel {
         card.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
-                displayRecipeController.execute(recipe.id());
+                System.out.println("Recipe card clicked. Recipe ID: " + recipe.id());
+                if (recipeClickListener != null) {
+                    recipeClickListener.accept(recipe.id()); // Trigger the listener with the recipe ID
+                }
             }
         });
 


### PR DESCRIPTION
Major changes for displaying the recipe details:
- Fixed DisplayRecipeState to encapsulate recipe details (title, image, ingredients, instructions, error handling).
 - Updated DisplayRecipePresenter to handle conversion of Ingredient and Instruction entities to displayable strings.
 - Updated DisplayRecipeView to load and display recipe details, including ingredients, instructions, and image from URL.
 - Added addRecipeClickListener method in SearchRecipeView. It allows the main application to listen for clicks on a recipe card and receive the clicked recipe's ID, which can then be passed to DisplayRecipeView.
 
I added debugging statements to track the app flow. Below is an example of printed statements from a working app:

Recipe card clicked. Recipe ID: 661259
DisplayRecipeController received recipe ID: 661259
DisplayRecipeInteractor executing with recipe ID: 661259
DisplayRecipePresenter updating the ViewModel with recipe details