### PR TITLE
Refactored everything to utilize view manager

### DIFF
--- a/src/main/java/app/DisplayRecipeAppBuilder.java
+++ b/src/main/java/app/DisplayRecipeAppBuilder.java
@@ -11,6 +11,7 @@ import use_case.display_recipe.DisplayRecipeDataAccessInterface;
 import use_case.display_recipe.DisplayRecipeInteractor;
 import use_case.display_recipe.DisplayRecipeOutputBoundary;
 import view.DisplayRecipeView;
+import view.ViewManager;
 
 /**
  * Builder for the Display Recipe Application.
@@ -55,13 +56,13 @@ public class DisplayRecipeAppBuilder {
 
     /**
      * Creates the DisplayRecipeView and underlying DisplayRecipeViewModel.
-     *
+     * @param currentViewManagerModel the ViewManagerModel to use
      * @return this builder
      */
-    public DisplayRecipeAppBuilder addDisplayRecipeView() {
-        viewManagerModel = new ViewManagerModel();
+    public DisplayRecipeAppBuilder addDisplayRecipeView(ViewManagerModel currentViewManagerModel) {
+        viewManagerModel = currentViewManagerModel;
         displayRecipeViewModel = new DisplayRecipeViewModel();
-        displayRecipeView = new DisplayRecipeView(displayRecipeViewModel);
+        displayRecipeView = new DisplayRecipeView(displayRecipeViewModel, viewManagerModel);
         return this;
     }
 

--- a/src/main/java/app/GroceryListAppBuilder.java
+++ b/src/main/java/app/GroceryListAppBuilder.java
@@ -12,6 +12,7 @@ import use_case.grocery_list.GroceryListOutputBoundary;
 import view.GroceryListView;
 
 import javax.swing.*;
+import java.awt.*;
 
 /**
  * Builder for the Grocery List app.

--- a/src/main/java/app/GroceryListAppBuilder.java
+++ b/src/main/java/app/GroceryListAppBuilder.java
@@ -1,0 +1,83 @@
+package app;
+
+import data_access.Constants;
+import data_access.RecipeDataAccessObject;
+import interface_adapter.ViewManagerModel;
+import interface_adapter.grocery_list.GroceryListController;
+import interface_adapter.grocery_list.GroceryListPresenter;
+import interface_adapter.grocery_list.GroceryListViewModel;
+import use_case.grocery_list.GroceryListDataAccessInterface;
+import use_case.grocery_list.GroceryListInteractor;
+import use_case.grocery_list.GroceryListOutputBoundary;
+import view.GroceryListView;
+
+import javax.swing.*;
+
+/**
+ * Builder for the Grocery List app.
+ */
+public class GroceryListAppBuilder {
+    private GroceryListDataAccessInterface groceryListDAO;
+    private GroceryListViewModel groceryListViewModel = new GroceryListViewModel();
+    private GroceryListView groceryListView;
+    private GroceryListInteractor groceryListInteractor;
+    private ViewManagerModel viewManagerModel = new ViewManagerModel();
+
+    /**
+     * Adds the Grocery List DAO to the app.
+     * @param dao the Grocery List DAO
+     * @return this
+     */
+    public GroceryListAppBuilder addGroceryListDAO(GroceryListDataAccessInterface dao) {
+        this.groceryListDAO = dao;
+        return this;
+    }
+
+    /**
+     * Adds the Grocery List view to the app.
+     * @return this
+     */
+    public GroceryListAppBuilder addGroceryListView() {
+        viewManagerModel = new ViewManagerModel();
+        groceryListViewModel = new GroceryListViewModel();
+        groceryListView = new GroceryListView(groceryListViewModel);
+        return this;
+    }
+
+    /**
+     * Adds the Grocery List use case.
+     * @return this
+     * @throws IllegalStateException if the Grocery List view has not been added.
+     */
+    public GroceryListAppBuilder addGroceryListUseCase() throws IllegalStateException {
+        final GroceryListOutputBoundary output = new GroceryListPresenter(groceryListViewModel, viewManagerModel);
+        groceryListInteractor = new GroceryListInteractor(groceryListDAO, output);
+
+        final GroceryListController groceryListController = new GroceryListController(groceryListInteractor);
+
+        if (groceryListView == null) {
+            throw new IllegalStateException("You must add the Grocery List view before adding the use case.");
+        }
+
+        groceryListView.setController(groceryListController);
+        return this;
+    }
+
+    public GroceryListView getGroceryListView() {
+        return groceryListView;
+    }
+
+    /**
+     * Builds the Grocery List app into a JFrame.
+     * @return the Grocery List app
+     */
+    public JFrame build() {
+        final JFrame frame = new JFrame();
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        frame.setTitle("Grocery List");
+        frame.setSize(Constants.WIDTH, Constants.HEIGHT);
+
+        frame.add(groceryListView);
+        return frame;
+    }
+}

--- a/src/main/java/app/GroceryListAppBuilder.java
+++ b/src/main/java/app/GroceryListAppBuilder.java
@@ -38,10 +38,10 @@ public class GroceryListAppBuilder {
      * Adds the Grocery List view to the app.
      * @return this
      */
-    public GroceryListAppBuilder addGroceryListView() {
+    public GroceryListAppBuilder addGroceryListView(ViewManagerModel currentViewManagerModel) {
         viewManagerModel = new ViewManagerModel();
         groceryListViewModel = new GroceryListViewModel();
-        groceryListView = new GroceryListView(groceryListViewModel);
+        groceryListView = new GroceryListView(groceryListViewModel, currentViewManagerModel);
         return this;
     }
 

--- a/src/main/java/app/MainAppBuilder.java
+++ b/src/main/java/app/MainAppBuilder.java
@@ -1,0 +1,37 @@
+//package app;
+//
+//import interface_adapter.display_recipe.DisplayRecipeController;
+//
+//import javax.swing.*;
+//import java.awt.*;
+//
+//public class MainAppBuilder {
+//    private JFrame frame;
+//    private CardLayout cardLayout;
+//
+//    private SearchRecipeAppBuilder searchRecipeAppBuilder;
+//    private DisplayRecipeAppBuilder displayRecipeAppBuilder;
+//
+//    public MainAppBuilder() {
+//        frame = new JFrame("Recipe App");
+//        cardLayout = new CardLayout();
+//        searchRecipeAppBuilder = new SearchRecipeAppBuilder();
+//        displayRecipeAppBuilder = new DisplayRecipeAppBuilder();
+//    }
+//
+//    public MainAppBuilder addBuilder(JFrame frame, String constraint) {
+//        final Container contentPane = frame.getContentPane();
+//        frame.add(contentPane, constraint);
+//        return this;
+//    }
+//
+//    public MainAppBuilder configureEventListeners() {
+//        // Event listener to switch to Display view when a recipe is clicked
+//        searchBuilder.getSearchRecipeView().addRecipeClickListener(recipeId -> {
+//            displayBuilder.getDisplayRecipeView().loadRecipeDetails(recipeId);
+//            cardLayout.show(frame.getContentPane(), "displayView");
+//        });
+//    }
+//
+//
+//}

--- a/src/main/java/app/SearchRecipeAppBuilder.java
+++ b/src/main/java/app/SearchRecipeAppBuilder.java
@@ -54,15 +54,20 @@ public class SearchRecipeAppBuilder {
         return this;
     }
 
+    public SearchRecipeAppBuilder addViewManagerModel(ViewManagerModel viewManagerModel) {
+        this.viewManagerModel = viewManagerModel;
+        return this;
+    }
+
     /**
      * Creates the SearchRecipeView and underlying SearchRecipeViewModel.
-     *
+     * @param currentViewManagerModel the view manager model
      * @return this builder
      */
-    public SearchRecipeAppBuilder addSearchRecipeView() {
-        viewManagerModel = new ViewManagerModel();
+    public SearchRecipeAppBuilder addSearchRecipeView(ViewManagerModel currentViewManagerModel) {
+        this.viewManagerModel = currentViewManagerModel;
         searchrecipeViewModel = new SearchRecipeViewModel();
-        searchRecipeView = new SearchRecipeView(searchrecipeViewModel);
+        searchRecipeView = new SearchRecipeView(searchrecipeViewModel, viewManagerModel);
         return this;
     }
 

--- a/src/main/java/app/SearchRecipeApplication.java
+++ b/src/main/java/app/SearchRecipeApplication.java
@@ -71,7 +71,7 @@ public class SearchRecipeApplication {
 
         // Optionally add a back button in DisplayRecipeView to go back to SearchRecipeView
         displayBuilder.getDisplayRecipeView().addBackButtonListener(() -> cardLayout.show(frame.getContentPane(), "searchView"));
-
+        groceryListBuilder.getGroceryListView().addBackButtonListener(() -> cardLayout.show(frame.getContentPane(), "searchView"));
         // Show the frame
         frame.setVisible(true);
     }

--- a/src/main/java/app/SearchRecipeApplication.java
+++ b/src/main/java/app/SearchRecipeApplication.java
@@ -1,8 +1,12 @@
 package app;
 
 import data_access.RecipeDataAccessObject;
+import data_access.grocery_list.GroceryListDataAccessObject;
+import use_case.grocery_list.GroceryListDataAccessInterface;
 import use_case.search_recipe.SearchRecipeDataAccessInterface;
 import use_case.display_recipe.DisplayRecipeDataAccessInterface;
+import view.Profile;
+
 import javax.swing.JFrame;
 import java.awt.CardLayout;
 
@@ -12,6 +16,7 @@ public class SearchRecipeApplication {
 
         final SearchRecipeDataAccessInterface searchRecipeDAO = new RecipeDataAccessObject();
         final DisplayRecipeDataAccessInterface displayRecipeDAO = new RecipeDataAccessObject();
+        final GroceryListDataAccessInterface groceryListDAO = new GroceryListDataAccessObject();
 
         // Set up a frame with a CardLayout to handle view switching
         final JFrame frame = new JFrame();
@@ -35,9 +40,17 @@ public class SearchRecipeApplication {
                 .addDisplayRecipeView()
                 .addDisplayRecipeUseCase();
 
+        // We need to add things in this order
+        final GroceryListAppBuilder groceryListBuilder = new GroceryListAppBuilder();
+        groceryListBuilder.addGroceryListDAO(new GroceryListDataAccessObject())
+                .addGroceryListView()
+                .addGroceryListUseCase();
+
         // Add both views to the frame's CardLayout
         frame.add(searchBuilder.build().getContentPane(), "searchView");
         frame.add(displayBuilder.build().getContentPane(), "displayView");
+        frame.add(groceryListBuilder.build().getContentPane(), "groceryListView");
+
 
         // Set the initial view to the search view
         cardLayout.show(frame.getContentPane(), "searchView");
@@ -47,6 +60,14 @@ public class SearchRecipeApplication {
             displayBuilder.getDisplayRecipeView().loadRecipeDetails(recipeId);
             cardLayout.show(frame.getContentPane(), "displayView");
         });
+
+        // Event listener to switch to GroceryList view when GroceryList button is clicked
+        final Profile profile = searchBuilder.getSearchRecipeView().getProfile();
+        profile.getGroceryListButton().addActionListener(evt -> {
+            cardLayout.show(frame.getContentPane(), "groceryListView");
+            groceryListBuilder.getGroceryListView().updateGroceryList();
+        });
+
 
         // Optionally add a back button in DisplayRecipeView to go back to SearchRecipeView
         displayBuilder.getDisplayRecipeView().addBackButtonListener(() -> cardLayout.show(frame.getContentPane(), "searchView"));

--- a/src/main/java/app/SearchRecipeApplication.java
+++ b/src/main/java/app/SearchRecipeApplication.java
@@ -15,6 +15,7 @@ import java.awt.CardLayout;
 
 public class SearchRecipeApplication {
 
+    @SuppressWarnings({"checkstyle:UnusedLocalVariable", "checkstyle:SuppressWarnings"})
     public static void main(String[] args) {
 
         final SearchRecipeDataAccessInterface searchRecipeDAO = new RecipeDataAccessObject();
@@ -35,7 +36,9 @@ public class SearchRecipeApplication {
 
 
         // Set up view manager
-        ViewManagerModel viewManagerModel= new ViewManagerModel();
+        final ViewManagerModel viewManagerModel= new ViewManagerModel();
+        // DO NOT DELETE THIS LINE
+        @SuppressWarnings("unused")
         final ViewManager viewManager = new ViewManager(frame.getContentPane(), cardLayout, viewManagerModel);
 
 
@@ -63,14 +66,6 @@ public class SearchRecipeApplication {
         // Set the initial view to the search view
         cardLayout.show(frame.getContentPane(), Constants.SEARCH_VIEW);
 
-        // Event listener to switch to Display view when a recipe is clicked
-//        searchBuilder.getSearchRecipeView().addRecipeClickListener(recipeId -> {
-//            displayBuilder.getDisplayRecipeView().loadRecipeDetails(recipeId);
-//            cardLayout.show(frame.getContentPane(), "displayView");
-//        });
-
-        // Optionally add a back button in DisplayRecipeView to go back to SearchRecipeView
-//        displayBuilder.getDisplayRecipeView().addBackButtonListener(() -> cardLayout.show(frame.getContentPane(), "searchView"));// Show the frame
         frame.setVisible(true);
     }
 }

--- a/src/main/java/app/SearchRecipeApplication.java
+++ b/src/main/java/app/SearchRecipeApplication.java
@@ -1,5 +1,6 @@
 package app;
 
+import data_access.Constants;
 import data_access.RecipeDataAccessObject;
 import data_access.grocery_list.GroceryListDataAccessObject;
 import interface_adapter.ViewManagerModel;
@@ -45,7 +46,7 @@ public class SearchRecipeApplication {
 
         final DisplayRecipeAppBuilder displayBuilder = new DisplayRecipeAppBuilder();
         displayBuilder.addDisplayRecipeDAO(displayRecipeDAO)
-                .addDisplayRecipeView()
+                .addDisplayRecipeView(viewManagerModel)
                 .addDisplayRecipeUseCase();
 
         // We need to add things in this order
@@ -55,36 +56,21 @@ public class SearchRecipeApplication {
                 .addGroceryListUseCase();
 
         // Add both views to the frame's CardLayout
-        frame.add(searchBuilder.build().getContentPane(), "searchView");
-        frame.add(displayBuilder.build().getContentPane(), "displayView");
-        frame.add(groceryListBuilder.build().getContentPane(), "groceryListView");
-
+        frame.add(searchBuilder.build().getContentPane(), Constants.SEARCH_VIEW);
+        frame.add(displayBuilder.build().getContentPane(), Constants.DISPLAY_RECIPE_VIEW);
+        frame.add(groceryListBuilder.build().getContentPane(), Constants.GROCERY_LIST_VIEW);
 
         // Set the initial view to the search view
-        cardLayout.show(frame.getContentPane(), "searchView");
+        cardLayout.show(frame.getContentPane(), Constants.SEARCH_VIEW);
 
         // Event listener to switch to Display view when a recipe is clicked
-        searchBuilder.getSearchRecipeView().addRecipeClickListener(recipeId -> {
-            displayBuilder.getDisplayRecipeView().loadRecipeDetails(recipeId);
-            cardLayout.show(frame.getContentPane(), "displayView");
-        });
-
-
-        // Event listener to switch to GroceryList view when GroceryList button is clicked
-//        final Profile profile = searchBuilder.getSearchRecipeView().getProfile();
-//        profile.getGroceryListButton().addActionListener(evt -> {
-//            // this should update the viewmanagermodel.
-//
-//
-//            cardLayout.show(frame.getContentPane(), "groceryListView");
-//            groceryListBuilder.getGroceryListView().updateGroceryList();
+//        searchBuilder.getSearchRecipeView().addRecipeClickListener(recipeId -> {
+//            displayBuilder.getDisplayRecipeView().loadRecipeDetails(recipeId);
+//            cardLayout.show(frame.getContentPane(), "displayView");
 //        });
 
-
         // Optionally add a back button in DisplayRecipeView to go back to SearchRecipeView
-        displayBuilder.getDisplayRecipeView().addBackButtonListener(() -> cardLayout.show(frame.getContentPane(), "searchView"));
-        groceryListBuilder.getGroceryListView().addBackButtonListener(() -> cardLayout.show(frame.getContentPane(), "searchView"));
-        // Show the frame
+//        displayBuilder.getDisplayRecipeView().addBackButtonListener(() -> cardLayout.show(frame.getContentPane(), "searchView"));// Show the frame
         frame.setVisible(true);
     }
 }

--- a/src/main/java/app/SearchRecipeApplication.java
+++ b/src/main/java/app/SearchRecipeApplication.java
@@ -2,10 +2,12 @@ package app;
 
 import data_access.RecipeDataAccessObject;
 import data_access.grocery_list.GroceryListDataAccessObject;
+import interface_adapter.ViewManagerModel;
 import use_case.grocery_list.GroceryListDataAccessInterface;
 import use_case.search_recipe.SearchRecipeDataAccessInterface;
 import use_case.display_recipe.DisplayRecipeDataAccessInterface;
 import view.Profile;
+import view.ViewManager;
 
 import javax.swing.JFrame;
 import java.awt.CardLayout;
@@ -30,9 +32,15 @@ public class SearchRecipeApplication {
         CardLayout cardLayout = new CardLayout();
         frame.setLayout(cardLayout);
 
+
+        // Set up view manager
+        ViewManagerModel viewManagerModel= new ViewManagerModel();
+        final ViewManager viewManager = new ViewManager(frame.getContentPane(), cardLayout, viewManagerModel);
+
+
         final SearchRecipeAppBuilder searchBuilder = new SearchRecipeAppBuilder();
         searchBuilder.addSearchRecipeDAO(searchRecipeDAO)
-                .addSearchRecipeView()
+                .addSearchRecipeView(viewManagerModel)
                 .addSearchRecipeUseCase();
 
         final DisplayRecipeAppBuilder displayBuilder = new DisplayRecipeAppBuilder();
@@ -43,7 +51,7 @@ public class SearchRecipeApplication {
         // We need to add things in this order
         final GroceryListAppBuilder groceryListBuilder = new GroceryListAppBuilder();
         groceryListBuilder.addGroceryListDAO(new GroceryListDataAccessObject())
-                .addGroceryListView()
+                .addGroceryListView(viewManagerModel)
                 .addGroceryListUseCase();
 
         // Add both views to the frame's CardLayout
@@ -61,12 +69,16 @@ public class SearchRecipeApplication {
             cardLayout.show(frame.getContentPane(), "displayView");
         });
 
+
         // Event listener to switch to GroceryList view when GroceryList button is clicked
-        final Profile profile = searchBuilder.getSearchRecipeView().getProfile();
-        profile.getGroceryListButton().addActionListener(evt -> {
-            cardLayout.show(frame.getContentPane(), "groceryListView");
-            groceryListBuilder.getGroceryListView().updateGroceryList();
-        });
+//        final Profile profile = searchBuilder.getSearchRecipeView().getProfile();
+//        profile.getGroceryListButton().addActionListener(evt -> {
+//            // this should update the viewmanagermodel.
+//
+//
+//            cardLayout.show(frame.getContentPane(), "groceryListView");
+//            groceryListBuilder.getGroceryListView().updateGroceryList();
+//        });
 
 
         // Optionally add a back button in DisplayRecipeView to go back to SearchRecipeView

--- a/src/main/java/data_access/Constants.java
+++ b/src/main/java/data_access/Constants.java
@@ -1,0 +1,12 @@
+package data_access;
+
+/**
+ * Constants for the data access layer.
+ */
+public class Constants {
+    public static final String API_KEY = "e6a971c78acb49dcbb4e5b324c05d436";
+    public static final String STATUS_CODE_LABEL = "status_code";
+    public static final int SUCCESS_CODE = 200;
+    public static final String MESSAGE = "message";
+}
+

--- a/src/main/java/data_access/Constants.java
+++ b/src/main/java/data_access/Constants.java
@@ -13,5 +13,10 @@ public class Constants {
     // UI
     public static final int HEIGHT = 800;
     public static final int WIDTH = 1200;
+
+    // page management
+    public static final String SEARCH_VIEW = "searchView";
+    public static final String DISPLAY_RECIPE_VIEW = "displayRecipeView";
+    public static final String GROCERY_LIST_VIEW = "groceryListView";
 }
 

--- a/src/main/java/data_access/Constants.java
+++ b/src/main/java/data_access/Constants.java
@@ -4,9 +4,14 @@ package data_access;
  * Constants for the data access layer.
  */
 public class Constants {
-    public static final String API_KEY = "e6a971c78acb49dcbb4e5b324c05d436";
+    // data access
+    public static final String API_KEY = "8c57d019b3ec4934bad61b670ecc45a9";
     public static final String STATUS_CODE_LABEL = "status_code";
     public static final int SUCCESS_CODE = 200;
     public static final String MESSAGE = "message";
+
+    // UI
+    public static final int HEIGHT = 800;
+    public static final int WIDTH = 1200;
 }
 

--- a/src/main/java/data_access/RecipeDataAccessObject.java
+++ b/src/main/java/data_access/RecipeDataAccessObject.java
@@ -21,7 +21,7 @@ import use_case.display_recipe.DisplayRecipeDataAccessInterface;
  * Implements both SearchRecipeDataAccessInterface and DisplayRecipeDataAccessInterface.
  */
 public class RecipeDataAccessObject implements SearchRecipeDataAccessInterface, DisplayRecipeDataAccessInterface {
-    private static final String API_KEY = "e6a971c78acb49dcbb4e5b324c05d436";
+    private static final String API_KEY = Constants.API_KEY;
     private static final String BASE_SEARCH_URL = "https://api.spoonacular.com/recipes/complexSearch";
     private static final String BASE_DETAILS_URL = "https://api.spoonacular.com/recipes/%d/information?&apiKey=%s&includeNutrition=true";
 

--- a/src/main/java/data_access/grocery_list/GroceryListDataAccessObject.java
+++ b/src/main/java/data_access/grocery_list/GroceryListDataAccessObject.java
@@ -1,0 +1,107 @@
+package data_access.grocery_list;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import data_access.Constants;
+import entity.CommonIngredient;
+import entity.Ingredient;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import use_case.grocery_list.GroceryListDataAccessInterface;
+
+
+
+/**
+ * Data access object for the GroceryList.
+ */
+public class GroceryListDataAccessObject implements GroceryListDataAccessInterface {
+    private static final String API_KEY = Constants.API_KEY;
+    private static final String STATUS_CODE_LABEL = Constants.STATUS_CODE_LABEL;
+    private static final int SUCCESS_CODE = Constants.SUCCESS_CODE;
+    private static final String MESSAGE = "message";
+
+    private final OkHttpClient client;
+
+    public GroceryListDataAccessObject() {
+        this.client = new OkHttpClient();
+    }
+
+    @Override
+    public List<Integer> getAllRecipeIds() {
+        // TODO get all recipe ids from the profile api.
+        final List<Integer> res = new ArrayList<>();
+        res.add(716429);
+        res.add(654959);
+        return res;
+    }
+
+    @Override
+    public List<Ingredient> getAllIngredients(List<Integer> ids) {
+        final List<Ingredient> res = new ArrayList<>();
+        for (int id : ids) {
+            final List<Ingredient> ingredient = getIngredientByRecipeId(id);
+            res.addAll(ingredient);
+        }
+        return res;
+    }
+
+    private List<Ingredient> getIngredientByRecipeId(int id) {
+        final JSONObject json = getIngredientJsonById(id);
+        return jsonToIngredients(json);
+    }
+
+    /**
+     * Get the JSON object for an ingredient by its ID.
+     *
+     * @param id The ID of the ingredient.
+     * @return The JSON object.
+     * @throws GroceryListException If the request fails.
+     */
+    private JSONObject getIngredientJsonById(int id) throws GroceryListException {
+        final String url = String.format(
+                "https://api.spoonacular.com/recipes/%d/ingredientWidget.json?apiKey=%s",
+                id, API_KEY);
+
+        final Request request = new Request.Builder()
+                .url(url)
+                .get()
+                .build();
+
+        try {
+            final Response response = client.newCall(request).execute();
+
+            final JSONObject responseBody = new JSONObject(response.body().string());
+
+            return responseBody;
+        }
+        catch (IOException | JSONException ex) {
+            throw new GroceryListException("Failed to get ingredient JSON: " + ex.getMessage());
+        }
+    }
+
+    // This should already be implemented somewhere.
+    private List<Ingredient> jsonToIngredients(JSONObject json) {
+        // This part maybe goes into json parser maybe not
+        // I've realized that it should only go into json parser if it is generic.
+        // But this may be only used by this class.
+        final List<Ingredient> res = new ArrayList<>();
+        final JSONArray ingredients = json.getJSONArray("ingredients");
+        for (int i = 0; i < ingredients.length(); i++) {
+            final JSONObject amount = ingredients.getJSONObject(i)
+                            .getJSONObject("amount")
+                            .getJSONObject("metric");
+            final String name = ingredients.getJSONObject(i).getString("name");
+            final String unit = amount.getString("unit");
+            final int value = amount.getInt("value");
+            final Ingredient tmp = new CommonIngredient(name, value, unit);
+            res.add(tmp);
+        }
+        return res;
+    }
+}

--- a/src/main/java/data_access/grocery_list/GroceryListException.java
+++ b/src/main/java/data_access/grocery_list/GroceryListException.java
@@ -1,0 +1,10 @@
+package data_access.grocery_list;
+
+/**
+ * Exception for the GroceryList data access.
+ */
+public class GroceryListException extends RuntimeException {
+    public GroceryListException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/entity/CommonIngredient.java
+++ b/src/main/java/entity/CommonIngredient.java
@@ -1,18 +1,27 @@
 package entity;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * The representation of an ingredient in our program.
  */
 public class CommonIngredient implements Ingredient {
     private String name;
     private float amount;
-    private int id;
+    @Nullable
+    private Integer id;
     private String unit;
 
     public CommonIngredient(String name, float amount, int id, String unit) {
         this.name = name;
         this.amount = amount;
         this.id = id;
+        this.unit = unit;
+    }
+
+    public CommonIngredient(String name, float amount, String unit) {
+        this.name = name;
+        this.amount = amount;
         this.unit = unit;
     }
 

--- a/src/main/java/entity/UserProfile.java
+++ b/src/main/java/entity/UserProfile.java
@@ -1,47 +1,47 @@
-package entity;
-
-import java.util.ArrayList;
-import java.util.List;
-
-/**
- * The representation of a user profile in our program.
- */
-public class UserProfile {
-    private final User user;
-    private final List<Recipe> favoriteMeals;
-    private final List<DietaryRestriction> dietaryRestrictions;
-
-    public UserProfile(User user) {
-        this.user = user;
-        this.favoriteMeals = new ArrayList<>();
-        this.dietaryRestrictions = new ArrayList<>();
-    }
-
-    public User getUser() {
-        return user;
-    }
-
-    public List<Recipe> getFavoriteMeals() {
-        return favoriteMeals;
-    }
-
-    public void addFavoriteMeals(Recipe recipe) {
-        favoriteMeals.add(recipe);
-    }
-
-    public void removeFavoriteMeals(Recipe recipe) {
-        favoriteMeals.remove(recipe);
-    }
-
-    public List<DietaryRestriction> getDietaryRestrictions() {
-        return dietaryRestrictions;
-    }
-
-    public void addDietaryRestriction(DietaryRestriction restriction) {
-        dietaryRestrictions.add(restriction);
-    }
-
-    public void removeDietaryRestriction(DietaryRestriction restriction) {
-        dietaryRestrictions.remove(restriction);
-    }
-}
+//package entity;
+//
+//import java.util.ArrayList;
+//import java.util.List;
+//
+///**
+// * The representation of a user profile in our program.
+// */
+//public class UserProfile {
+//    private final User user;
+//    private final List<Recipe> favoriteMeals;
+//    private final List<DietaryRestriction> dietaryRestrictions;
+//
+//    public UserProfile(User user) {
+//        this.user = user;
+//        this.favoriteMeals = new ArrayList<>();
+//        this.dietaryRestrictions = new ArrayList<>();
+//    }
+//
+//    public User getUser() {
+//        return user;
+//    }
+//
+//    public List<Recipe> getFavoriteMeals() {
+//        return favoriteMeals;
+//    }
+//
+//    public void addFavoriteMeals(Recipe recipe) {
+//        favoriteMeals.add(recipe);
+//    }
+//
+//    public void removeFavoriteMeals(Recipe recipe) {
+//        favoriteMeals.remove(recipe);
+//    }
+//
+//    public List<DietaryRestriction> getDietaryRestrictions() {
+//        return dietaryRestrictions;
+//    }
+//
+//    public void addDietaryRestriction(DietaryRestriction restriction) {
+//        dietaryRestrictions.add(restriction);
+//    }
+//
+//    public void removeDietaryRestriction(DietaryRestriction restriction) {
+//        dietaryRestrictions.remove(restriction);
+//    }
+//}

--- a/src/main/java/interface_adapter/ViewManagerModel.java
+++ b/src/main/java/interface_adapter/ViewManagerModel.java
@@ -4,10 +4,10 @@ package interface_adapter;
  * Model for the View Manager. Its state is the name of the View which
  * is currently active. An initial state of "" is used.
  */
-public class ViewManagerModel extends ViewModel<String> {
+public class ViewManagerModel extends ViewModel<ViewManagerState> {
 
     public ViewManagerModel() {
         super("view manager");
-        this.setState("");
+        this.setState(new ViewManagerState());
     }
 }

--- a/src/main/java/interface_adapter/ViewManagerState.java
+++ b/src/main/java/interface_adapter/ViewManagerState.java
@@ -1,0 +1,40 @@
+package interface_adapter;
+
+/**
+ * The state of the View Manager. It contains the name of the view
+ * and the context of the view (which could be for example the id).
+ */
+public class ViewManagerState {
+    private String viewName;
+    private Object context;
+
+    // Constructor
+    public ViewManagerState(String viewName, Object context) {
+        this.viewName = viewName;
+        this.context = context;
+    }
+
+    public ViewManagerState() {
+
+    }
+
+    // Getter for viewName
+    public String getViewName() {
+        return viewName;
+    }
+
+    // Setter for viewName
+    public void setViewName(String viewName) {
+        this.viewName = viewName;
+    }
+
+    // Getter for context
+    public Object getContext() {
+        return context;
+    }
+
+    // Setter for context
+    public void setContext(Object context) {
+        this.context = context;
+    }
+}

--- a/src/main/java/interface_adapter/ViewModel.java
+++ b/src/main/java/interface_adapter/ViewModel.java
@@ -14,6 +14,8 @@ public class ViewModel<T> {
 
     private final String viewName;
 
+    private Object context;
+
     private final PropertyChangeSupport support = new PropertyChangeSupport(this);
 
     private T state;
@@ -32,6 +34,14 @@ public class ViewModel<T> {
 
     public void setState(T state) {
         this.state = state;
+    }
+
+    public Object getContext() {
+        return this.context;
+    }
+
+    public void setContext(Object context) {
+        this.context = context;
     }
 
     /**

--- a/src/main/java/interface_adapter/display_recipe/DisplayRecipePresenter.java
+++ b/src/main/java/interface_adapter/display_recipe/DisplayRecipePresenter.java
@@ -42,7 +42,7 @@ public class DisplayRecipePresenter implements DisplayRecipeOutputBoundary {
         );
 
         // Switch the view state
-        viewManager.setState(displayRecipeViewModel.getViewName());
+//        viewManager.setState(displayRecipeViewModel.getViewName());
     }
 
     @Override

--- a/src/main/java/interface_adapter/grocery_list/GroceryListController.java
+++ b/src/main/java/interface_adapter/grocery_list/GroceryListController.java
@@ -1,0 +1,22 @@
+package interface_adapter.grocery_list;
+
+import use_case.grocery_list.GroceryListInputBoundary;
+
+/**
+ * The controller for the Grocery List View.
+ */
+public class GroceryListController {
+    private final GroceryListInputBoundary groceryListInputBoundary;
+
+    public GroceryListController(GroceryListInputBoundary groceryListInputBoundary) {
+        this.groceryListInputBoundary = groceryListInputBoundary;
+    }
+
+    /**
+     * Executes the Grocery List use case.
+     * We don't need anything since we get it from the api.
+     */
+    public void execute() {
+        groceryListInputBoundary.execute();
+    }
+}

--- a/src/main/java/interface_adapter/grocery_list/GroceryListPresenter.java
+++ b/src/main/java/interface_adapter/grocery_list/GroceryListPresenter.java
@@ -1,0 +1,36 @@
+package interface_adapter.grocery_list;
+
+import interface_adapter.ViewManagerModel;
+import use_case.grocery_list.GroceryListOutputBoundary;
+import use_case.grocery_list.GroceryListOutputData;
+
+/**
+ * Presenter for the grocery list view.
+ */
+public class GroceryListPresenter implements GroceryListOutputBoundary {
+
+    private final GroceryListViewModel groceryListViewModel;
+    private ViewManagerModel viewManagerModel;
+
+    public GroceryListPresenter(GroceryListViewModel groceryListViewModel, ViewManagerModel viewManagerModel) {
+        this.groceryListViewModel = groceryListViewModel;
+        this.viewManagerModel = viewManagerModel;
+    }
+
+    @Override
+    public void prepareSuccessView(GroceryListOutputData response) {
+        final GroceryListState state = groceryListViewModel.getState();
+        state.setList(response.getGroceryList());
+        groceryListViewModel.firePropertyChanged();
+
+        viewManagerModel.setState(groceryListViewModel.getViewName());
+        viewManagerModel.firePropertyChanged();
+    }
+
+    @Override
+    public void prepareFailView(String error) {
+        final GroceryListState state = groceryListViewModel.getState();
+        state.setError(error);
+        groceryListViewModel.firePropertyChanged();
+    }
+}

--- a/src/main/java/interface_adapter/grocery_list/GroceryListPresenter.java
+++ b/src/main/java/interface_adapter/grocery_list/GroceryListPresenter.java
@@ -23,8 +23,8 @@ public class GroceryListPresenter implements GroceryListOutputBoundary {
         state.setList(response.getGroceryList());
         groceryListViewModel.firePropertyChanged();
 
-        viewManagerModel.setState(groceryListViewModel.getViewName());
-        viewManagerModel.firePropertyChanged();
+//        viewManagerModel.setState(groceryListViewModel.getViewName());
+//        viewManagerModel.firePropertyChanged();
     }
 
     @Override

--- a/src/main/java/interface_adapter/grocery_list/GroceryListState.java
+++ b/src/main/java/interface_adapter/grocery_list/GroceryListState.java
@@ -1,0 +1,30 @@
+package interface_adapter.grocery_list;
+
+import java.util.List;
+
+/**
+ * The state of the Grocery List.
+ */
+public class GroceryListState {
+    private List<String> list;
+    private String error;
+
+    /*
+     * Each item in the list corresponds to a line in the view
+     */
+    public List<String> getList() {
+        return list;
+    }
+
+    public void setList(List<String> list) {
+        this.list = list;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+}

--- a/src/main/java/interface_adapter/grocery_list/GroceryListViewModel.java
+++ b/src/main/java/interface_adapter/grocery_list/GroceryListViewModel.java
@@ -1,0 +1,14 @@
+package interface_adapter.grocery_list;
+
+import interface_adapter.ViewModel;
+
+/**
+ * The View Model for the Grocery List View.
+ */
+public class GroceryListViewModel extends ViewModel<GroceryListState> {
+    public GroceryListViewModel() {
+        super("grocery list");
+        setState(new GroceryListState());
+    }
+
+}

--- a/src/main/java/interface_adapter/login/LoginPresenter.java
+++ b/src/main/java/interface_adapter/login/LoginPresenter.java
@@ -24,14 +24,14 @@ public class LoginPresenter implements LoginOutputBoundary {
 
     @Override
     public void prepareSuccessView(LoginOutputData response){
-        // On success, switch to logged in view
-        final LoggedInState loggedInState = new loggedInViewModel.getState();
-        loggedInState.setUsername(response.getUsername());
-        this.loggedInViewModel.setState(loggedInState);
-        this.loggedInViewModel.firePropertyChanged();
-
-        this.viewManagerModel.setState(loggedInViewModel.getViewName());
-        this.viewManagerModel.firePropertyChanged();
+//        // On success, switch to logged in view
+//        final LoggedInState loggedInState = new loggedInViewModel.getState();
+//        loggedInState.setUsername(response.getUsername());
+//        this.loggedInViewModel.setState(loggedInState);
+//        this.loggedInViewModel.firePropertyChanged();
+//
+//        this.viewManagerModel.setState(loggedInViewModel.getViewName());
+//        this.viewManagerModel.firePropertyChanged();
     }
 
     @Override

--- a/src/main/java/interface_adapter/logout/LogoutPresenter.java
+++ b/src/main/java/interface_adapter/logout/LogoutPresenter.java
@@ -40,8 +40,8 @@ public class LogoutPresenter implements LogoutOutputBoundary {
         this.loginViewModel.firePropertyChanged();
 
         // Switch to login view.
-        this.viewManagerModel.setState(loginViewModel.getViewName());
-        this.viewManagerModel.firePropertyChanged();
+//        this.viewManagerModel.setState(loginViewModel.getViewName());
+//        this.viewManagerModel.firePropertyChanged();
     }
 
     @Override

--- a/src/main/java/interface_adapter/search_recipe/SearchRecipePresenter.java
+++ b/src/main/java/interface_adapter/search_recipe/SearchRecipePresenter.java
@@ -31,8 +31,8 @@ public class SearchRecipePresenter implements SearchRecipeOutputBoundary {
         searchRecipeViewModel.firePropertyChanged("recipes");
 
         // Optionally, switch the view to show the search results.
-        viewManagerModel.setState("SearchResultsView");
-        viewManagerModel.firePropertyChanged();
+//        viewManagerModel.setState("SearchResultsView");
+//        viewManagerModel.firePropertyChanged();
     }
 
     /**

--- a/src/main/java/interface_adapter/signup/SignupPresenter.java
+++ b/src/main/java/interface_adapter/signup/SignupPresenter.java
@@ -30,8 +30,8 @@ public class SignupPresenter implements SignupOutputBoundary {
         this.loginViewModel.setState(loginState);
         loginViewModel.firePropertyChanged();
 
-        viewManagerModel.setState(loginViewModel.getViewName());
-        viewManagerModel.firePropertyChanged();
+//        viewManagerModel.setState(loginViewModel.getViewName());
+//        viewManagerModel.firePropertyChanged();
     }
 
     @Override
@@ -43,7 +43,7 @@ public class SignupPresenter implements SignupOutputBoundary {
 
     @Override
     public void switchToLoginView(){
-        viewManagerModel.setState(loginViewModel.getViewName());
-        viewManagerModel.firePropertyChanged();
+//        viewManagerModel.setState(loginViewModel.getViewName());
+//        viewManagerModel.firePropertyChanged();
     }
 }

--- a/src/main/java/use_case/grocery_list/GroceryListDataAccessInterface.java
+++ b/src/main/java/use_case/grocery_list/GroceryListDataAccessInterface.java
@@ -1,0 +1,24 @@
+package use_case.grocery_list;
+
+import java.util.List;
+
+import entity.Ingredient;
+
+/**
+ * Interface for the GroceryList data access.
+ */
+public interface GroceryListDataAccessInterface {
+    /**
+     * Get all ingredients from a list of recipe ids.
+     *
+     * @param ids The list of recipe IDs.
+     * @return The list of ingredients.
+     */
+    List<Ingredient> getAllIngredients(List<Integer> ids);
+    /**
+     * Get all recipe IDs for this week
+     *
+     * @return The list of recipe IDs.
+     */
+    List<Integer> getAllRecipeIds();
+}

--- a/src/main/java/use_case/grocery_list/GroceryListInputBoundary.java
+++ b/src/main/java/use_case/grocery_list/GroceryListInputBoundary.java
@@ -1,0 +1,11 @@
+package use_case.grocery_list;
+
+/**
+ * The input boundary for the Grocery list use case.
+ */
+public interface GroceryListInputBoundary {
+    /**
+     * Executes the use case.
+     */
+    void execute();
+}

--- a/src/main/java/use_case/grocery_list/GroceryListInputData.java
+++ b/src/main/java/use_case/grocery_list/GroceryListInputData.java
@@ -1,0 +1,20 @@
+package use_case.grocery_list;
+
+import java.util.List;
+
+/**
+ * Input data for the GroceryList use case.
+ */
+public class GroceryListInputData {
+
+    private final int userId;
+
+    public GroceryListInputData(int userId) {
+        this.userId = userId;
+    }
+
+    public int getUserId() {
+        return userId;
+    }
+
+}

--- a/src/main/java/use_case/grocery_list/GroceryListInteractor.java
+++ b/src/main/java/use_case/grocery_list/GroceryListInteractor.java
@@ -1,0 +1,57 @@
+package use_case.grocery_list;
+
+import java.util.List;
+
+import data_access.grocery_list.GroceryListException;
+import entity.Ingredient;
+
+/**
+ * The interactor for the Grocery List use case.
+ */
+public class GroceryListInteractor implements GroceryListInputBoundary{
+
+    private final GroceryListDataAccessInterface dataAccess;
+    private final GroceryListOutputBoundary presenter;
+
+    public GroceryListInteractor(GroceryListDataAccessInterface dataAccess,
+                                 GroceryListOutputBoundary presenter) {
+        this.dataAccess = dataAccess;
+        this.presenter = presenter;
+    }
+
+    @Override
+    public void execute() {
+        // Get recipe ids from the profile api
+        final List<Integer> recipeIds = dataAccess.getAllRecipeIds();
+
+        try {
+            // Get ingredients from the recipe ids
+            final List<Ingredient> ingredients = dataAccess.getAllIngredients(recipeIds);
+            // Convert ingredients to strings
+            final List<String> ingredientStrings = ingredientsToStrings(ingredients);
+
+            final GroceryListOutputData outputData = new GroceryListOutputData(ingredientStrings);
+            presenter.prepareSuccessView(outputData);
+        }
+        catch (GroceryListException ex) {
+            presenter.prepareFailView(ex.getMessage());
+        }
+    }
+
+    /**
+     * Convert a list of ingredients to a list of strings.
+     *
+     * @param ingredients The list of ingredients.
+     * @return The list of strings.
+     */
+    private List<String> ingredientsToStrings(List<Ingredient> ingredients) {
+        final List<String> res = new java.util.ArrayList<>();
+        for (Ingredient ingredient : ingredients) {
+            final String name = ingredient.getName();
+            final float value = ingredient.getAmount();
+            final String unit = ingredient.getUnit();
+            res.add(name + " - " + value + " " + unit);
+        }
+        return res;
+    }
+}

--- a/src/main/java/use_case/grocery_list/GroceryListOutputBoundary.java
+++ b/src/main/java/use_case/grocery_list/GroceryListOutputBoundary.java
@@ -1,0 +1,14 @@
+package use_case.grocery_list;
+
+public interface GroceryListOutputBoundary {
+    /**
+     * Prepares the view to display the grocery list.
+     * @param outputData The output data from the use case.
+     */
+    void prepareSuccessView(GroceryListOutputData outputData);
+    /**
+     * Prepares the view to display an error message.
+     * @param errorMessage The error message to display.
+     */
+    void prepareFailView(String errorMessage);
+}

--- a/src/main/java/use_case/grocery_list/GroceryListOutputData.java
+++ b/src/main/java/use_case/grocery_list/GroceryListOutputData.java
@@ -1,0 +1,18 @@
+package use_case.grocery_list;
+
+import java.util.List;
+
+/**
+ * Output data for the GroceryList use case.
+ */
+public class GroceryListOutputData {
+    private final List<String> groceryList;
+
+    public GroceryListOutputData(List<String> groceryList) {
+        this.groceryList = groceryList;
+    }
+
+    public List<String> getGroceryList() {
+        return groceryList;
+    }
+}

--- a/src/main/java/view/GroceryListView.java
+++ b/src/main/java/view/GroceryListView.java
@@ -1,5 +1,6 @@
 package view;
 
+import interface_adapter.ViewManagerModel;
 import interface_adapter.grocery_list.GroceryListController;
 import interface_adapter.grocery_list.GroceryListState;
 import interface_adapter.grocery_list.GroceryListViewModel;
@@ -17,6 +18,7 @@ import java.util.List;
 public class GroceryListView extends JPanel implements PropertyChangeListener {
     private final String viewName = "grocery list";
     private final GroceryListViewModel groceryListViewModel;
+    private final ViewManagerModel viewManagerModel;
 
     private final JButton returnButton;
     private final List<JLabel> groceryList;
@@ -27,12 +29,15 @@ public class GroceryListView extends JPanel implements PropertyChangeListener {
 
     /**
      * Creates a new GroceryListView.
-     *
+     * @param viewManagerModel The view manager model.
      * @param groceryListViewModel The view model for the grocery list.
      */
-    public GroceryListView(GroceryListViewModel groceryListViewModel) {
+    public GroceryListView(GroceryListViewModel groceryListViewModel,
+                           ViewManagerModel viewManagerModel) {
         this.groceryListViewModel = groceryListViewModel;
         this.groceryListViewModel.addPropertyChangeListener(this);
+        this.viewManagerModel = viewManagerModel;
+        this.viewManagerModel.addPropertyChangeListener(this);
         this.returnButton = new JButton("Return");
         returnButton.addActionListener(evt -> {
             System.out.println("Return button pressed");
@@ -50,8 +55,15 @@ public class GroceryListView extends JPanel implements PropertyChangeListener {
     }
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        final GroceryListState state = (GroceryListState) evt.getNewValue();
-        refreshPage(state);
+        if (evt.getNewValue() instanceof GroceryListState) {
+            final GroceryListState state = (GroceryListState) evt.getNewValue();
+            refreshPage(state);
+        }
+        if (evt.getNewValue() instanceof String) {
+            if (evt.getNewValue().equals("groceryListView")) {
+                updateGroceryList();
+            }
+        }
     }
 
     private void refreshPage(GroceryListState state) {

--- a/src/main/java/view/GroceryListView.java
+++ b/src/main/java/view/GroceryListView.java
@@ -1,6 +1,8 @@
 package view;
 
+import data_access.Constants;
 import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewManagerState;
 import interface_adapter.grocery_list.GroceryListController;
 import interface_adapter.grocery_list.GroceryListState;
 import interface_adapter.grocery_list.GroceryListViewModel;
@@ -25,7 +27,6 @@ public class GroceryListView extends JPanel implements PropertyChangeListener {
 
     private GroceryListController controller;
 
-    private Runnable backButtonListener;
 
     /**
      * Creates a new GroceryListView.
@@ -41,7 +42,9 @@ public class GroceryListView extends JPanel implements PropertyChangeListener {
         this.returnButton = new JButton("Return");
         returnButton.addActionListener(evt -> {
             System.out.println("Return button pressed");
-            backButtonListener.run();
+            final ViewManagerState state = new ViewManagerState(Constants.SEARCH_VIEW, null);
+            viewManagerModel.setState(state);
+            viewManagerModel.firePropertyChanged();
         }
         );
 
@@ -50,17 +53,15 @@ public class GroceryListView extends JPanel implements PropertyChangeListener {
         this.add(returnButton);
     }
 
-    public void addBackButtonListener(Runnable listener) {
-        this.backButtonListener = listener;
-    }
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getNewValue() instanceof GroceryListState) {
             final GroceryListState state = (GroceryListState) evt.getNewValue();
             refreshPage(state);
         }
-        if (evt.getNewValue() instanceof String) {
-            if (evt.getNewValue().equals("groceryListView")) {
+        if (evt.getNewValue() instanceof ViewManagerState) {
+            final ViewManagerState state = (ViewManagerState) evt.getNewValue();
+            if (state.getViewName().equals(Constants.GROCERY_LIST_VIEW)) {
                 updateGroceryList();
             }
         }

--- a/src/main/java/view/GroceryListView.java
+++ b/src/main/java/view/GroceryListView.java
@@ -5,10 +5,8 @@ import interface_adapter.grocery_list.GroceryListState;
 import interface_adapter.grocery_list.GroceryListViewModel;
 
 import javax.swing.*;
-import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.sql.Array;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,6 +20,8 @@ public class GroceryListView extends JPanel implements PropertyChangeListener {
     private final JButton returnButton;
     private final List<JLabel> groceryList;
 
+    private GroceryListController controller;
+
     public GroceryListView(GroceryListViewModel groceryListViewModel) {
         this.groceryListViewModel = groceryListViewModel;
         this.groceryListViewModel.addPropertyChangeListener(this);
@@ -34,10 +34,10 @@ public class GroceryListView extends JPanel implements PropertyChangeListener {
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
         final GroceryListState state = (GroceryListState) evt.getNewValue();
-        updateGroceryList(state);
+        refreshPage(state);
     }
 
-    private void updateGroceryList(GroceryListState state) {
+    private void refreshPage(GroceryListState state) {
         this.removeAll();
         this.add(returnButton);
         this.groceryList.clear();
@@ -50,5 +50,13 @@ public class GroceryListView extends JPanel implements PropertyChangeListener {
 
         this.revalidate();
         this.repaint();
+    }
+
+    public void setController(GroceryListController controller) {
+        this.controller = controller;
+    }
+
+    public void updateGroceryList() {
+        controller.execute();
     }
 }

--- a/src/main/java/view/GroceryListView.java
+++ b/src/main/java/view/GroceryListView.java
@@ -5,6 +5,7 @@ import interface_adapter.grocery_list.GroceryListState;
 import interface_adapter.grocery_list.GroceryListViewModel;
 
 import javax.swing.*;
+import java.awt.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
@@ -22,15 +23,31 @@ public class GroceryListView extends JPanel implements PropertyChangeListener {
 
     private GroceryListController controller;
 
+    private Runnable backButtonListener;
+
+    /**
+     * Creates a new GroceryListView.
+     *
+     * @param groceryListViewModel The view model for the grocery list.
+     */
     public GroceryListView(GroceryListViewModel groceryListViewModel) {
         this.groceryListViewModel = groceryListViewModel;
         this.groceryListViewModel.addPropertyChangeListener(this);
         this.returnButton = new JButton("Return");
+        returnButton.addActionListener(evt -> {
+            System.out.println("Return button pressed");
+            backButtonListener.run();
+        }
+        );
+
         this.groceryList = new ArrayList<>();
         this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS)); // Set layout to BoxLayout with vertical alignment
         this.add(returnButton);
     }
 
+    public void addBackButtonListener(Runnable listener) {
+        this.backButtonListener = listener;
+    }
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
         final GroceryListState state = (GroceryListState) evt.getNewValue();

--- a/src/main/java/view/GroceryListView.java
+++ b/src/main/java/view/GroceryListView.java
@@ -1,0 +1,54 @@
+package view;
+
+import interface_adapter.grocery_list.GroceryListController;
+import interface_adapter.grocery_list.GroceryListState;
+import interface_adapter.grocery_list.GroceryListViewModel;
+
+import javax.swing.*;
+import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.sql.Array;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The View for the grocery list.
+ */
+public class GroceryListView extends JPanel implements PropertyChangeListener {
+    private final String viewName = "grocery list";
+    private final GroceryListViewModel groceryListViewModel;
+
+    private final JButton returnButton;
+    private final List<JLabel> groceryList;
+
+    public GroceryListView(GroceryListViewModel groceryListViewModel) {
+        this.groceryListViewModel = groceryListViewModel;
+        this.groceryListViewModel.addPropertyChangeListener(this);
+        this.returnButton = new JButton("Return");
+        this.groceryList = new ArrayList<>();
+        this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS)); // Set layout to BoxLayout with vertical alignment
+        this.add(returnButton);
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        final GroceryListState state = (GroceryListState) evt.getNewValue();
+        updateGroceryList(state);
+    }
+
+    private void updateGroceryList(GroceryListState state) {
+        this.removeAll();
+        this.add(returnButton);
+        this.groceryList.clear();
+
+        for (String item : state.getList()) {
+            final JLabel label = new JLabel(item);
+            this.groceryList.add(label);
+            this.add(label);
+        }
+
+        this.revalidate();
+        this.repaint();
+    }
+}

--- a/src/main/java/view/Profile.java
+++ b/src/main/java/view/Profile.java
@@ -1,6 +1,8 @@
 package view;
 
+import data_access.Constants;
 import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewManagerState;
 
 import javax.swing.*;
 import java.awt.*;
@@ -35,7 +37,8 @@ public class Profile extends JPanel {
             @Override
             public void actionPerformed(ActionEvent e) {
                 System.out.println("Grocery List button clicked");
-                viewManagerModel.setState("groceryListView");
+                ViewManagerState state = new ViewManagerState(Constants.GROCERY_LIST_VIEW, null);
+                viewManagerModel.setState(state);
                 viewManagerModel.firePropertyChanged();
             }
         });

--- a/src/main/java/view/Profile.java
+++ b/src/main/java/view/Profile.java
@@ -1,0 +1,139 @@
+package view;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+// Custom Profile class
+public class Profile extends JPanel {
+    private Color circleColor = Color.GRAY;
+    private JPopupMenu profileDropDown;
+    private JMenuItem groceryListButton;
+
+    public Profile() {
+        setPreferredSize(new Dimension(55, 55));
+        setOpaque(false);
+        setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+
+        // Initialize the popup menu
+        profileDropDown = new JPopupMenu();
+        profileDropDown.setBackground(Color.DARK_GRAY);
+        profileDropDown.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+
+        JMenuItem profileButton = new JMenuItem("Profile");
+        JMenuItem favoriteButton = new JMenuItem("Favorite");
+        JMenuItem mealPlanButton = new JMenuItem("Meal Plan");
+        this.groceryListButton = new JMenuItem("Grocery List");
+        // add listener to groceryListButton
+        groceryListButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                System.out.println("Grocery List button clicked");
+
+            }
+        });
+        JMenuItem dietButton = new JMenuItem("Diet");
+        JMenuItem logoutButton = new JMenuItem("Logout");
+
+        customizeButton(profileButton);
+        customizeButton(favoriteButton);
+        customizeButton(mealPlanButton);
+        customizeButton(groceryListButton);
+        customizeButton(dietButton);
+        customizeButton(logoutButton);
+
+        profileDropDown.add(profileButton);
+        profileDropDown.add(favoriteButton);
+        profileDropDown.add(mealPlanButton);
+        profileDropDown.add(groceryListButton);
+        profileDropDown.add(dietButton);
+        profileDropDown.addSeparator();
+        profileDropDown.add(logoutButton);
+
+        // Add hover effect for the dropdown
+        addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseEntered(MouseEvent e) {
+                circleColor = Color.DARK_GRAY;
+                repaint();
+                // Show the popup menu below the circle
+                profileDropDown.show(Profile.this, -70, getHeight());
+            }
+
+            @Override
+            public void mouseExited(MouseEvent e) {
+                // Check if mouse exits both the Profile and dropdown
+                Point mouseLocation = e.getLocationOnScreen();
+                SwingUtilities.convertPointFromScreen(mouseLocation, profileDropDown);
+                if (!profileDropDown.getBounds().contains(mouseLocation)) {
+                    circleColor = Color.GRAY;
+                    profileDropDown.setVisible(false);
+                    repaint();
+                }
+            }
+        });
+
+        profileDropDown.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseExited(MouseEvent e) {
+                // Check if mouse is still near the menu bounds
+                Point mouseLocation = e.getLocationOnScreen();
+                SwingUtilities.convertPointFromScreen(mouseLocation, profileDropDown);
+
+                Rectangle extendedBounds = new Rectangle(-10, -10,
+                        profileDropDown.getWidth() + 20,
+                        profileDropDown.getHeight() + 20);
+
+                if (!extendedBounds.contains(mouseLocation)) {
+                    profileDropDown.setVisible(false);
+                }
+            }
+        });
+    }
+
+    public JMenuItem getGroceryListButton() {
+        return groceryListButton;
+    }
+
+    private void customizeButton(JMenuItem item) {
+        item.setBackground(Color.DARK_GRAY);
+        item.setForeground(Color.WHITE);
+        item.setFont(new Font("SansSerif", Font.BOLD, 12));
+        item.setOpaque(true);
+        item.setPreferredSize(new Dimension(120,40));
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+
+        Graphics2D g2d = (Graphics2D) g.create();
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+        // Determine size and position
+        int diameter = Math.min(getWidth(), getHeight()) - 1;
+        int x = (getWidth() - diameter) / 2;
+        int y = (getHeight() - diameter) / 2;
+
+        // Draw the circle
+        g2d.setColor(circleColor);
+        g2d.fillOval(x, y, diameter, diameter);
+
+        // Optionally, draw initials or an icon in the circle
+        g2d.setColor(Color.WHITE);
+        g2d.setFont(new Font("SansSerif", Font.BOLD, diameter / 2));
+        FontMetrics fm = g2d.getFontMetrics();
+
+        String initials = "P";
+        int stringWidth = fm.stringWidth(initials);
+        int stringHeight = fm.getAscent();
+        int textX = x + (diameter - stringWidth) / 2;
+        int textY = y + (diameter + stringHeight) / 2 - 4;
+        g2d.drawString(initials, textX, textY);
+
+        g2d.dispose();
+    }
+}

--- a/src/main/java/view/Profile.java
+++ b/src/main/java/view/Profile.java
@@ -1,5 +1,7 @@
 package view;
 
+import interface_adapter.ViewManagerModel;
+
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -12,8 +14,9 @@ public class Profile extends JPanel {
     private Color circleColor = Color.GRAY;
     private JPopupMenu profileDropDown;
     private JMenuItem groceryListButton;
+    private ViewManagerModel viewManagerModel;
 
-    public Profile() {
+    public Profile(ViewManagerModel viewManagerModel) {
         setPreferredSize(new Dimension(55, 55));
         setOpaque(false);
         setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
@@ -32,7 +35,8 @@ public class Profile extends JPanel {
             @Override
             public void actionPerformed(ActionEvent e) {
                 System.out.println("Grocery List button clicked");
-
+                viewManagerModel.setState("groceryListView");
+                viewManagerModel.firePropertyChanged();
             }
         });
         JMenuItem dietButton = new JMenuItem("Diet");

--- a/src/main/java/view/SearchRecipeView.java
+++ b/src/main/java/view/SearchRecipeView.java
@@ -1,7 +1,9 @@
 package view;
 
+import data_access.Constants;
 import data_access.RecipeDataAccessObject;
 import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewManagerState;
 import interface_adapter.display_recipe.DisplayRecipeController;
 import interface_adapter.display_recipe.DisplayRecipePresenter;
 import interface_adapter.display_recipe.DisplayRecipeViewModel;
@@ -328,9 +330,14 @@ public class SearchRecipeView extends JPanel {
             @Override
             public void mouseClicked(MouseEvent e) {
                 System.out.println("Recipe card clicked. Recipe ID: " + recipe.id());
-                if (recipeClickListener != null) {
-                    recipeClickListener.accept(recipe.id()); // Trigger the listener with the recipe ID
-                }
+
+                final ViewManagerState state = new ViewManagerState(
+                        Constants.DISPLAY_RECIPE_VIEW,
+                        recipe.id());
+                viewManagerModel.setState(state);
+                viewManagerModel.setContext(recipe.id());
+                viewManagerModel.firePropertyChanged();
+
             }
         });
 

--- a/src/main/java/view/SearchRecipeView.java
+++ b/src/main/java/view/SearchRecipeView.java
@@ -44,26 +44,27 @@ public class SearchRecipeView extends JPanel {
 
     //
     private JMenuItem profileButton;
+
+    private ViewManagerModel viewManagerModel;
     /**
      * Constructor for the SearchRecipeView.
      * @param viewModel the ViewModel for the Search Recipe Use Case
+     * @param viewManagerModel the ViewManagerModel
      */
-    public SearchRecipeView(SearchRecipeViewModel viewModel) {
+    public SearchRecipeView(SearchRecipeViewModel viewModel,
+                            ViewManagerModel viewManagerModel) {
         this.viewModel = viewModel;
         setLayout(new BorderLayout());
-
+        this.viewManagerModel = viewManagerModel;
         loadScreen();
         registerPropertyChangeListeners();
     }
 
-    public Profile getProfile() {
-        return profile;
-    }
 
     private void loadScreen() {
 
         // Create the profile component
-        profile = new Profile();
+        profile = new Profile(this.viewManagerModel);
 
         // Create the search bar with rounded corners and shadow
         searchBar = createSearchBar();

--- a/src/main/java/view/SearchRecipeView.java
+++ b/src/main/java/view/SearchRecipeView.java
@@ -42,6 +42,8 @@ public class SearchRecipeView extends JPanel {
     private final int cornerRadius = 50;
     private Consumer<Integer> recipeClickListener;
 
+    //
+    private JMenuItem profileButton;
     /**
      * Constructor for the SearchRecipeView.
      * @param viewModel the ViewModel for the Search Recipe Use Case
@@ -52,6 +54,10 @@ public class SearchRecipeView extends JPanel {
 
         loadScreen();
         registerPropertyChangeListeners();
+    }
+
+    public Profile getProfile() {
+        return profile;
     }
 
     private void loadScreen() {
@@ -200,123 +206,6 @@ public class SearchRecipeView extends JPanel {
         }
     }
 
-    // Custom Profile class
-    class Profile extends JPanel {
-        private Color circleColor = Color.GRAY;
-        private JPopupMenu profileDropDown;
-
-        public Profile() {
-            setPreferredSize(new Dimension(55, 55));
-            setOpaque(false);
-            setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-
-            // Initialize the popup menu
-            profileDropDown = new JPopupMenu();
-            profileDropDown.setBackground(Color.DARK_GRAY);
-            profileDropDown.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-
-            JMenuItem profileButton = new JMenuItem("Profile");
-            JMenuItem favoriteButton = new JMenuItem("Favorite");
-            JMenuItem mealPlanButton = new JMenuItem("Meal Plan");
-            JMenuItem groceryListButton = new JMenuItem("Grocery List");
-            JMenuItem dietButton = new JMenuItem("Diet");
-            JMenuItem logoutButton = new JMenuItem("Logout");
-
-            customizeButton(profileButton);
-            customizeButton(favoriteButton);
-            customizeButton(mealPlanButton);
-            customizeButton(groceryListButton);
-            customizeButton(dietButton);
-            customizeButton(logoutButton);
-
-            profileDropDown.add(profileButton);
-            profileDropDown.add(favoriteButton);
-            profileDropDown.add(mealPlanButton);
-            profileDropDown.add(groceryListButton);
-            profileDropDown.add(dietButton);
-            profileDropDown.addSeparator();
-            profileDropDown.add(logoutButton);
-
-            // Add hover effect for the dropdown
-            addMouseListener(new MouseAdapter() {
-                @Override
-                public void mouseEntered(MouseEvent e) {
-                    circleColor = Color.DARK_GRAY;
-                    repaint();
-                    // Show the popup menu below the circle
-                    profileDropDown.show(Profile.this, -70, getHeight());
-                }
-
-                @Override
-                public void mouseExited(MouseEvent e) {
-                    // Check if mouse exits both the Profile and dropdown
-                    Point mouseLocation = e.getLocationOnScreen();
-                    SwingUtilities.convertPointFromScreen(mouseLocation, profileDropDown);
-                    if (!profileDropDown.getBounds().contains(mouseLocation)) {
-                        circleColor = Color.GRAY;
-                        profileDropDown.setVisible(false);
-                        repaint();
-                    }
-                }
-            });
-
-            profileDropDown.addMouseListener(new MouseAdapter() {
-                @Override
-                public void mouseExited(MouseEvent e) {
-                    // Check if mouse is still near the menu bounds
-                    Point mouseLocation = e.getLocationOnScreen();
-                    SwingUtilities.convertPointFromScreen(mouseLocation, profileDropDown);
-
-                    Rectangle extendedBounds = new Rectangle(-10, -10,
-                            profileDropDown.getWidth() + 20,
-                            profileDropDown.getHeight() + 20);
-
-                    if (!extendedBounds.contains(mouseLocation)) {
-                        profileDropDown.setVisible(false);
-                    }
-                }
-            });
-        }
-
-        private void customizeButton(JMenuItem item) {
-            item.setBackground(Color.DARK_GRAY);
-            item.setForeground(Color.WHITE);
-            item.setFont(new Font("SansSerif", Font.BOLD, 12));
-            item.setOpaque(true);
-            item.setPreferredSize(new Dimension(120,40));
-        }
-
-        @Override
-        protected void paintComponent(Graphics g) {
-            super.paintComponent(g);
-
-            Graphics2D g2d = (Graphics2D) g.create();
-            g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-
-            // Determine size and position
-            int diameter = Math.min(getWidth(), getHeight()) - 1;
-            int x = (getWidth() - diameter) / 2;
-            int y = (getHeight() - diameter) / 2;
-
-            // Draw the circle
-            g2d.setColor(circleColor);
-            g2d.fillOval(x, y, diameter, diameter);
-
-            // Optionally, draw initials or an icon in the circle
-            g2d.setColor(Color.WHITE);
-            g2d.setFont(new Font("SansSerif", Font.BOLD, diameter / 2));
-            FontMetrics fm = g2d.getFontMetrics();
-
-            String initials = "P";
-            int stringWidth = fm.stringWidth(initials);
-            int stringHeight = fm.getAscent();
-            int textX = x + (diameter - stringWidth) / 2;
-            int textY = y + (diameter + stringHeight) / 2 - 4;
-            g2d.drawString(initials, textX, textY);
-
-            g2d.dispose();
-        }
-    }
 
     private void registerPropertyChangeListeners() {
         viewModel.addPropertyChangeListener(new PropertyChangeListener() {
@@ -423,14 +312,14 @@ public class SearchRecipeView extends JPanel {
         nameLabel.setBorder(new EmptyBorder(10, 10, 10, 10));
         card.add(nameLabel, BorderLayout.SOUTH);
 
-        final ViewManagerModel viewManagerModel = new ViewManagerModel();
-        DisplayRecipePresenter displayRecipePresenter = new DisplayRecipePresenter(viewManagerModel,
-                new DisplayRecipeViewModel());
-        DisplayRecipeDataAccessInterface displayRecipeDataAccessInterface = new RecipeDataAccessObject();
-        DisplayRecipeInputBoundary displayRecipeUseCaseInteractor = new DisplayRecipeInteractor(
-                displayRecipePresenter, displayRecipeDataAccessInterface);
-
-        final DisplayRecipeController displayRecipeController = new DisplayRecipeController(displayRecipeUseCaseInteractor);
+//        final ViewManagerModel viewManagerModel = new ViewManagerModel();
+//        DisplayRecipePresenter displayRecipePresenter = new DisplayRecipePresenter(viewManagerModel,
+//                new DisplayRecipeViewModel());
+//        DisplayRecipeDataAccessInterface displayRecipeDataAccessInterface = new RecipeDataAccessObject();
+//        DisplayRecipeInputBoundary displayRecipeUseCaseInteractor = new DisplayRecipeInteractor(
+//                displayRecipePresenter, displayRecipeDataAccessInterface);
+//
+//        final DisplayRecipeController displayRecipeController = new DisplayRecipeController(displayRecipeUseCaseInteractor);
 
         card.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 

--- a/src/main/java/view/ViewManager.java
+++ b/src/main/java/view/ViewManager.java
@@ -13,10 +13,10 @@ import java.beans.PropertyChangeListener;
  */
 public class ViewManager implements PropertyChangeListener {
     private final CardLayout cardLayout;
-    private final JPanel views;
+    private final Container views;
     private final ViewManagerModel viewManagerModel;
 
-    public ViewManager(JPanel views, CardLayout cardLayout, ViewManagerModel viewManagerModel) {
+    public ViewManager(Container views, CardLayout cardLayout, ViewManagerModel viewManagerModel) {
         this.views = views;
         this.cardLayout = cardLayout;
         this.viewManagerModel = viewManagerModel;

--- a/src/main/java/view/ViewManager.java
+++ b/src/main/java/view/ViewManager.java
@@ -1,6 +1,7 @@
 package view;
 
 import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewManagerState;
 
 import javax.swing.*;
 import java.awt.*;
@@ -25,7 +26,7 @@ public class ViewManager implements PropertyChangeListener {
 
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        final String viewModelName = (String) evt.getNewValue();
-        cardLayout.show(views, viewModelName);
+        final ViewManagerState state = (ViewManagerState) evt.getNewValue();
+        cardLayout.show(views, state.getViewName());
     }
 }

--- a/src/test/java/view/GroceryListEndToEnd.java
+++ b/src/test/java/view/GroceryListEndToEnd.java
@@ -15,25 +15,25 @@ import javax.swing.*;
 
 public class GroceryListEndToEnd {
     public static void main(String[] args) {
-        // add the view to the frame
-        GroceryListViewModel groceryListViewModel = new GroceryListViewModel();
-        JPanel groceryListView = new GroceryListView(groceryListViewModel);
-        JFrame frame = new JFrame("test");
-        frame.setContentPane(groceryListView);
-        frame.setSize(800, 600);
-        frame.setVisible(true);
-
-        // add the use case
-        final ViewManagerModel viewManagerModel = new ViewManagerModel();
-        final GroceryListOutputBoundary outputBoundary = new GroceryListPresenter(groceryListViewModel, viewManagerModel);
-
-        GroceryListDataAccessInterface dataAccess = new GroceryListDataAccessObject();
-        GroceryListOutputBoundary presenter = new GroceryListPresenter(groceryListViewModel, viewManagerModel);
-        final GroceryListInputBoundary inputBoundary = new GroceryListInteractor(dataAccess, presenter);
-
-        // add the controller
-        GroceryListController controller = new GroceryListController(inputBoundary);
-        // execute use case
-        controller.execute();
+//        // add the view to the frame
+//        GroceryListViewModel groceryListViewModel = new GroceryListViewModel();
+//        JPanel groceryListView = new GroceryListView(groceryListViewModel);
+//        JFrame frame = new JFrame("test");
+//        frame.setContentPane(groceryListView);
+//        frame.setSize(800, 600);
+//        frame.setVisible(true);
+//
+//        // add the use case
+//        final ViewManagerModel viewManagerModel = new ViewManagerModel();
+//        final GroceryListOutputBoundary outputBoundary = new GroceryListPresenter(groceryListViewModel, viewManagerModel);
+//
+//        GroceryListDataAccessInterface dataAccess = new GroceryListDataAccessObject();
+//        GroceryListOutputBoundary presenter = new GroceryListPresenter(groceryListViewModel, viewManagerModel);
+//        final GroceryListInputBoundary inputBoundary = new GroceryListInteractor(dataAccess, presenter);
+//
+//        // add the controller
+//        GroceryListController controller = new GroceryListController(inputBoundary);
+//        // execute use case
+//        controller.execute();
     }
 }

--- a/src/test/java/view/GroceryListEndToEnd.java
+++ b/src/test/java/view/GroceryListEndToEnd.java
@@ -1,0 +1,39 @@
+package view;
+
+import data_access.grocery_list.GroceryListDataAccessObject;
+import interface_adapter.ViewManagerModel;
+import interface_adapter.grocery_list.GroceryListController;
+import interface_adapter.grocery_list.GroceryListPresenter;
+import interface_adapter.grocery_list.GroceryListViewModel;
+import org.junit.Test;
+import use_case.grocery_list.GroceryListDataAccessInterface;
+import use_case.grocery_list.GroceryListInteractor;
+import use_case.grocery_list.GroceryListOutputBoundary;
+import use_case.grocery_list.GroceryListInputBoundary;
+
+import javax.swing.*;
+
+public class GroceryListEndToEnd {
+    public static void main(String[] args) {
+        // add the view to the frame
+        GroceryListViewModel groceryListViewModel = new GroceryListViewModel();
+        JPanel groceryListView = new GroceryListView(groceryListViewModel);
+        JFrame frame = new JFrame("test");
+        frame.setContentPane(groceryListView);
+        frame.setSize(800, 600);
+        frame.setVisible(true);
+
+        // add the use case
+        final ViewManagerModel viewManagerModel = new ViewManagerModel();
+        final GroceryListOutputBoundary outputBoundary = new GroceryListPresenter(groceryListViewModel, viewManagerModel);
+
+        GroceryListDataAccessInterface dataAccess = new GroceryListDataAccessObject();
+        GroceryListOutputBoundary presenter = new GroceryListPresenter(groceryListViewModel, viewManagerModel);
+        final GroceryListInputBoundary inputBoundary = new GroceryListInteractor(dataAccess, presenter);
+
+        // add the controller
+        GroceryListController controller = new GroceryListController(inputBoundary);
+        // execute use case
+        controller.execute();
+    }
+}


### PR DESCRIPTION
Firstly here is why I had to do this:
- The main method had lots of code already and we only had 3 use cases
- This also meant that the main method was very tightly coupled: there were listeners being added, there were back buttons being added, etc. Overall, it should not be the main method's job to switch views. It should be the view manager's job. Also the back buttons should be the specific use case's job to return back to the main page and this code should not be in the main method if we want to adhere to single responsibility principle and decoupling.

Here is what changed:
- Firstly, everything uses the view manager to switch between views. To do this, you must create a ViewManagerState then write this:
                viewManagerModel.setState(state);
                viewManagerModel.firePropertyChanged();
The above code switches views
- The ViewManagerState has two variables. The first is the viewName, which is the name of the view to switch to. These names are in a file called Constants. The second name is called context, which is not needed by most use cases but sometimes, like for the displayRecipe usecase, it needed the id, so this is where we could put the id into context. Context is of type object, so any custom object can go in here.
- As for how to listen to when a page has changed to your page, inside of your view, inside of your propertyChange(PropertyChangeEvent evt) function that you overrode, you can check if (evt.getNewValue() instanceof ViewManagerState) then do something. For example, most of the time, you would probably want to execute your use case whenever the view is switched to yours, so you can do that. Or in the case of the display recipe use case, we could also get the id from context.