### PR TITLE
Grocery list now normalizes units to grams and simplifies duplicate items

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,12 @@
             <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.8.1</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/app/SearchRecipeApplication.java
+++ b/src/main/java/app/SearchRecipeApplication.java
@@ -3,6 +3,7 @@ package app;
 import data_access.Constants;
 import data_access.RecipeDataAccessObject;
 import data_access.grocery_list.GroceryListDataAccessObject;
+import data_access.grocery_list.GroceryListInMemoryDataAccessObject;
 import interface_adapter.ViewManagerModel;
 import use_case.grocery_list.GroceryListDataAccessInterface;
 import use_case.search_recipe.SearchRecipeDataAccessInterface;
@@ -21,6 +22,7 @@ public class SearchRecipeApplication {
         final SearchRecipeDataAccessInterface searchRecipeDAO = new RecipeDataAccessObject();
         final DisplayRecipeDataAccessInterface displayRecipeDAO = new RecipeDataAccessObject();
         final GroceryListDataAccessInterface groceryListDAO = new GroceryListDataAccessObject();
+//        final GroceryListDataAccessInterface groceryListDAO = new GroceryListInMemoryDataAccessObject();
 
         // Set up a frame with a CardLayout to handle view switching
         final JFrame frame = new JFrame();
@@ -54,7 +56,7 @@ public class SearchRecipeApplication {
 
         // We need to add things in this order
         final GroceryListAppBuilder groceryListBuilder = new GroceryListAppBuilder();
-        groceryListBuilder.addGroceryListDAO(new GroceryListDataAccessObject())
+        groceryListBuilder.addGroceryListDAO(groceryListDAO)
                 .addGroceryListView(viewManagerModel)
                 .addGroceryListUseCase();
 

--- a/src/main/java/data_access/grocery_list/GroceryListDataAccessObject.java
+++ b/src/main/java/data_access/grocery_list/GroceryListDataAccessObject.java
@@ -5,8 +5,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import data_access.Constants;
-import entity.CommonIngredient;
-import entity.Ingredient;
+import entity.CommonMeasurable;
+import entity.CommonPair;
+import entity.Measurable;
+import entity.Pair;
+import entity.grocery_list.CommonIngredientWithConvertedUnits;
+import entity.grocery_list.IngredientWithConvertedUnits;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -25,6 +29,7 @@ public class GroceryListDataAccessObject implements GroceryListDataAccessInterfa
     private static final String STATUS_CODE_LABEL = Constants.STATUS_CODE_LABEL;
     private static final int SUCCESS_CODE = Constants.SUCCESS_CODE;
     private static final String MESSAGE = "message";
+    public static final String FAILURE = "failure";
 
     private final OkHttpClient client;
 
@@ -38,20 +43,21 @@ public class GroceryListDataAccessObject implements GroceryListDataAccessInterfa
         final List<Integer> res = new ArrayList<>();
         res.add(716429);
         res.add(654959);
+        res.add(654959); // add a duplicate to test the simplification
         return res;
     }
 
     @Override
-    public List<Ingredient> getAllIngredients(List<Integer> ids) {
-        final List<Ingredient> res = new ArrayList<>();
+    public List<IngredientWithConvertedUnits> getAllIngredients(List<Integer> ids) {
+        final List<IngredientWithConvertedUnits> res = new ArrayList<>();
         for (int id : ids) {
-            final List<Ingredient> ingredient = getIngredientByRecipeId(id);
+            final List<IngredientWithConvertedUnits> ingredient = getIngredientByRecipeId(id);
             res.addAll(ingredient);
         }
         return res;
     }
 
-    private List<Ingredient> getIngredientByRecipeId(int id) {
+    private List<IngredientWithConvertedUnits> getIngredientByRecipeId(int id) {
         final JSONObject json = getIngredientJsonById(id);
         return jsonToIngredients(json);
     }
@@ -86,22 +92,59 @@ public class GroceryListDataAccessObject implements GroceryListDataAccessInterfa
     }
 
     // This should already be implemented somewhere.
-    private List<Ingredient> jsonToIngredients(JSONObject json) {
+    private List<IngredientWithConvertedUnits> jsonToIngredients(JSONObject json) {
         // This part maybe goes into json parser maybe not
         // I've realized that it should only go into json parser if it is generic.
         // But this may be only used by this class.
-        final List<Ingredient> res = new ArrayList<>();
+        final List<IngredientWithConvertedUnits> res = new ArrayList<>();
         final JSONArray ingredients = json.getJSONArray("ingredients");
+        // loop through each ingredient and add it to the result res
         for (int i = 0; i < ingredients.length(); i++) {
             final JSONObject amount = ingredients.getJSONObject(i)
                             .getJSONObject("amount")
                             .getJSONObject("metric");
             final String name = ingredients.getJSONObject(i).getString("name");
             final String unit = amount.getString("unit");
-            final int value = amount.getInt("value");
-            final Ingredient tmp = new CommonIngredient(name, value, unit);
+            final float value = amount.getFloat("value");
+            final IngredientWithConvertedUnits tmp = new CommonIngredientWithConvertedUnits(name, value, unit);
+
+            // We need to convert the units to standard units grams.
+            final Pair<Measurable<Float>, Boolean> standardUnits = convertToStandardUnits(name, value, unit);
+
+            tmp.setConvertedAmount(standardUnits.getFirst().getNumber());
+            tmp.setConvertedUnit(standardUnits.getFirst().getUnit());
+            tmp.setConvertStatus(standardUnits.getSecond());
             res.add(tmp);
         }
         return res;
+    }
+
+    /**
+     * Convert the given value to standard units grams. Returns <converted value, status on whether or not successfully
+     * converted>.
+     *
+     * @param name The name of the ingredient.
+     * @param value The value of the ingredient.
+     * @param unit The unit of the ingredient.
+     * @return The converted value in standard units.
+     * @throws GroceryListException If the conversion fails.
+     */
+    Pair<Measurable<Float>, Boolean> convertToStandardUnits(String name, float value, String unit) throws GroceryListException {
+        final String url = String.format(
+                "https://api.spoonacular.com/recipes/convert?apiKey=%s&ingredientName=%s&sourceAmount=%f&sourceUnit=%s&targetUnit=grams",
+                API_KEY, name, value, unit);
+        final Request request = new Request.Builder()
+                .url(url)
+                .get()
+                .build();
+        try {
+            final Response response = client.newCall(request).execute();
+            final JSONObject responseBody = new JSONObject(response.body().string());
+            final Measurable res = new CommonMeasurable<>(responseBody.getFloat("targetAmount"), responseBody.getString("targetUnit"));
+            return new CommonPair<>(res, true);
+        }
+        catch (IOException | JSONException ex) {
+            return new CommonPair<>(new CommonMeasurable<>(0f, ""), false);
+        }
     }
 }

--- a/src/main/java/data_access/grocery_list/GroceryListInMemoryDataAccessObject.java
+++ b/src/main/java/data_access/grocery_list/GroceryListInMemoryDataAccessObject.java
@@ -1,0 +1,36 @@
+package data_access.grocery_list;
+
+import entity.grocery_list.CommonIngredientWithConvertedUnits;
+import entity.grocery_list.IngredientWithConvertedUnits;
+import use_case.grocery_list.GroceryListDataAccessInterface;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * In memory data access object for the GroceryList.
+ */
+public class GroceryListInMemoryDataAccessObject implements GroceryListDataAccessInterface {
+    private List<IngredientWithConvertedUnits> ingredients;
+
+    public GroceryListInMemoryDataAccessObject() {
+        // This is default dummy data
+        ingredients = new ArrayList<>();
+        ingredients.add(new CommonIngredientWithConvertedUnits("name1", 1f, "grams"));
+    }
+
+    public GroceryListInMemoryDataAccessObject(List<IngredientWithConvertedUnits> ingredients) {
+        // This is default dummy data
+        this.ingredients = ingredients;
+    }
+
+    @Override
+    public List<Integer> getAllRecipeIds() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<IngredientWithConvertedUnits> getAllIngredients(List<Integer> ids) {
+        return ingredients;
+    }
+}

--- a/src/main/java/entity/CommonIngredient.java
+++ b/src/main/java/entity/CommonIngredient.java
@@ -26,6 +26,16 @@ public class CommonIngredient implements Ingredient {
     }
 
     @Override
+    public void setAmount(float amount) {
+        this.amount = amount;
+    }
+
+    @Override
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+
+    @Override
     public String getName() {
         return name;
     }

--- a/src/main/java/entity/CommonPair.java
+++ b/src/main/java/entity/CommonPair.java
@@ -1,0 +1,43 @@
+package entity;
+
+/**
+ * A generic class representing a tuple of length 2.
+ *
+ * @param <T1> the type of the first element
+ * @param <T2> the type of the second element
+ */
+public class CommonPair<T1, T2> implements Pair<T1, T2> {
+    private final T1 first;
+    private final T2 second;
+
+    /**
+     * Constructs a new CommonPair with the specified elements.
+     *
+     * @param first the first element
+     * @param second the second element
+     */
+    public CommonPair(T1 first, T2 second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    /**
+     * Returns the first element of the pair.
+     *
+     * @return the first element
+     */
+    @Override
+    public T1 getFirst() {
+        return first;
+    }
+
+    /**
+     * Returns the second element of the pair.
+     *
+     * @return the second element
+     */
+    @Override
+    public T2 getSecond() {
+        return second;
+    }
+}

--- a/src/main/java/entity/Ingredient.java
+++ b/src/main/java/entity/Ingredient.java
@@ -18,10 +18,22 @@ public interface Ingredient {
     float getAmount();
 
     /**
+     * Sets the amount of this ingredient.
+     * @param amount the amount of this ingredient
+     */
+    void setAmount(float amount);
+
+    /**
      * Returns the unit of this ingredient.
      * @return the unit of this ingredient
      */
     String getUnit();
+
+    /**
+     * Sets the unit of this ingredient.
+     * @param unit the unit of this ingredient
+     */
+    void setUnit(String unit);
 
     /**
      * Returns the ID of this ingredient.

--- a/src/main/java/entity/Pair.java
+++ b/src/main/java/entity/Pair.java
@@ -1,0 +1,23 @@
+package entity;
+
+/**
+ * A generic interface representing a tuple of length 2.
+ *
+ * @param <T1> the type of the first element
+ * @param <T2> the type of the second element
+ */
+public interface Pair<T1, T2> {
+    /**
+     * Returns the first element of the pair.
+     *
+     * @return the first element
+     */
+    T1 getFirst();
+
+    /**
+     * Returns the second element of the pair.
+     *
+     * @return the second element
+     */
+    T2 getSecond();
+}

--- a/src/main/java/entity/grocery_list/CommonIngredientWithConvertedUnits.java
+++ b/src/main/java/entity/grocery_list/CommonIngredientWithConvertedUnits.java
@@ -1,0 +1,154 @@
+package entity.grocery_list;
+
+/**
+ * The representation of an ingredient in our program.
+ */
+public class CommonIngredientWithConvertedUnits implements IngredientWithConvertedUnits {
+    private String name;
+    private float sourceAmount;
+    private int id;
+    private String sourceUnit;
+    private String convertedUnit;
+    private float convertedAmount;
+    private boolean convertStatus;
+
+    /**
+     * Constructs a new CommonIngredientWithConvertedUnits with the specified details.
+     *
+     * @param name the name of the ingredient
+     * @param sourceAmount the original amount of the ingredient
+     * @param id the ID of the ingredient
+     * @param sourceUnit the original unit of the ingredient
+     * @param convertedUnit the converted unit of the ingredient
+     * @param convertedAmount the converted amount of the ingredient
+     * @param convertStatus the status of whether it was converted successfully
+     */
+    public CommonIngredientWithConvertedUnits(String name, float sourceAmount,
+                                              int id, String sourceUnit, String convertedUnit, float convertedAmount,
+                                              boolean convertStatus) {
+        this.name = name;
+        this.sourceAmount = sourceAmount;
+        this.id = id;
+        this.sourceUnit = sourceUnit;
+        this.convertedUnit = convertedUnit;
+        this.convertedAmount = convertedAmount;
+        this.convertStatus = convertStatus;
+    }
+
+    public CommonIngredientWithConvertedUnits(String name, float sourceAmount,
+                                              String sourceUnit) {
+        this.name = name;
+        this.sourceAmount = sourceAmount;
+        this.sourceUnit = sourceUnit;
+    }
+
+    @Override
+    public void setAmount(float amount) {
+        sourceAmount = amount;
+    }
+
+    @Override
+    public void setUnit(String unit) {
+        sourceUnit = unit;
+    }
+
+    @Override
+    public boolean getConvertStatus() {
+        return convertStatus;
+    }
+
+    @Override
+    public void setConvertStatus(boolean newStatus) {
+        convertStatus = newStatus;
+    }
+
+    /**
+     * Returns the name of this ingredient.
+     *
+     * @return the name of this ingredient
+     */
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the original amount of this ingredient.
+     *
+     * @return the original amount of this ingredient
+     */
+    @Override
+    public float getAmount() {
+        return sourceAmount;
+    }
+
+    /**
+     * Returns the ID of this ingredient.
+     *
+     * @return the ID of this ingredient
+     */
+    @Override
+    public int getID() {
+        return id;
+    }
+
+    /**
+     * Returns the original unit of this ingredient.
+     *
+     * @return the original unit of this ingredient
+     */
+    @Override
+    public String getUnit() {
+        return sourceUnit;
+    }
+
+    /**
+     * Returns the converted unit of this ingredient.
+     *
+     * @return the converted unit of this ingredient
+     */
+    @Override
+    public String getConvertedUnit() {
+        return convertedUnit;
+    }
+
+    /**
+     * Sets the converted unit of this ingredient.
+     *
+     * @param convertedUnit the converted unit of this ingredient
+     */
+    @Override
+    public void setConvertedUnit(String convertedUnit) {
+        this.convertedUnit = convertedUnit;
+    }
+
+    /**
+     * Returns the converted amount of this ingredient.
+     *
+     * @return the converted amount of this ingredient
+     */
+    @Override
+    public float getConvertedAmount() {
+        return convertedAmount;
+    }
+
+    /**
+     * Sets the converted amount of this ingredient.
+     *
+     * @param convertedAmount the converted amount of this ingredient
+     */
+    @Override
+    public void setConvertedAmount(float convertedAmount) {
+        this.convertedAmount = convertedAmount;
+    }
+
+    /**
+     * Returns a string representation of this ingredient.
+     *
+     * @return a string representation of this ingredient
+     */
+    @Override
+    public String toString() {
+        return getName() + " - " + getAmount() + " " + getUnit() + " (converted to " + getConvertedAmount() + " " + getConvertedUnit() + ")";
+    }
+}

--- a/src/main/java/entity/grocery_list/IngredientWithConvertedUnits.java
+++ b/src/main/java/entity/grocery_list/IngredientWithConvertedUnits.java
@@ -1,0 +1,44 @@
+package entity.grocery_list;
+
+import entity.Ingredient;
+
+/**
+ * This class is necessary for ingredients that have been converted to some standard.
+ */
+public interface IngredientWithConvertedUnits extends Ingredient {
+    /**
+     * Returns the converted/target unit of this ingredient.
+     * @return the unit of this ingredient
+     */
+    String getConvertedUnit();
+
+    /**
+     * Sets the converted/target unit of this ingredient.
+     * @param unit the unit of this ingredient
+     */
+    void setConvertedUnit(String unit);
+
+    /**
+     * Returns the converted/target amount, in grams of this ingredient.
+     * @return the amount, in grams of this ingredient
+     */
+    float getConvertedAmount();
+
+    /**
+     * Sets the converted/target amount, in grams of this ingredient.
+     * @param amount the amount, in grams of this ingredient
+     */
+    void setConvertedAmount(float amount);
+
+    /**
+     * Returns true if the ingredient is successfully converted, false otherwise.
+     * @return the status of this ingredient
+     */
+    boolean getConvertStatus();
+
+    /**
+     * Sets the status of whether or not it was converted successfully.
+     * @param newStatus the status of this ingredient
+     */
+    void setConvertStatus(boolean newStatus);
+}

--- a/src/main/java/use_case/grocery_list/GroceryListDataAccessInterface.java
+++ b/src/main/java/use_case/grocery_list/GroceryListDataAccessInterface.java
@@ -2,7 +2,7 @@ package use_case.grocery_list;
 
 import java.util.List;
 
-import entity.Ingredient;
+import entity.grocery_list.IngredientWithConvertedUnits;
 
 /**
  * Interface for the GroceryList data access.
@@ -14,9 +14,10 @@ public interface GroceryListDataAccessInterface {
      * @param ids The list of recipe IDs.
      * @return The list of ingredients.
      */
-    List<Ingredient> getAllIngredients(List<Integer> ids);
+    List<IngredientWithConvertedUnits> getAllIngredients(List<Integer> ids);
+
     /**
-     * Get all recipe IDs for this week
+     * Get all recipe IDs for this week.
      *
      * @return The list of recipe IDs.
      */

--- a/src/main/java/use_case/grocery_list/GroceryListInteractor.java
+++ b/src/main/java/use_case/grocery_list/GroceryListInteractor.java
@@ -1,14 +1,19 @@
 package use_case.grocery_list;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import data_access.grocery_list.GroceryListException;
+import entity.CommonIngredient;
 import entity.Ingredient;
+import entity.grocery_list.IngredientWithConvertedUnits;
 
 /**
  * The interactor for the Grocery List use case.
  */
-public class GroceryListInteractor implements GroceryListInputBoundary{
+public class GroceryListInteractor implements GroceryListInputBoundary {
 
     private final GroceryListDataAccessInterface dataAccess;
     private final GroceryListOutputBoundary presenter;
@@ -21,12 +26,11 @@ public class GroceryListInteractor implements GroceryListInputBoundary{
 
     @Override
     public void execute() {
-        // Get recipe ids from the profile api
-        final List<Integer> recipeIds = dataAccess.getAllRecipeIds();
-
         try {
+            // Get recipe ids from the profile api
+            final List<Integer> recipeIds = dataAccess.getAllRecipeIds();
             // Get ingredients from the recipe ids
-            final List<Ingredient> ingredients = dataAccess.getAllIngredients(recipeIds);
+            final List<IngredientWithConvertedUnits> ingredients = dataAccess.getAllIngredients(recipeIds);
             // Convert ingredients to strings
             final List<String> ingredientStrings = ingredientsToStrings(ingredients);
 
@@ -39,18 +43,73 @@ public class GroceryListInteractor implements GroceryListInputBoundary{
     }
 
     /**
-     * Convert a list of ingredients to a list of strings.
+     * Convert a list of ingredients to a list of strings based on the standard unit grams
      *
      * @param ingredients The list of ingredients.
      * @return The list of strings.
      */
-    private List<String> ingredientsToStrings(List<Ingredient> ingredients) {
+    List<String> ingredientsToStrings(List<IngredientWithConvertedUnits> ingredients) {
+        // We first need to simplify the ingredients and add duplicate names.
+        final List<Ingredient> simplifiedIngredients = simplifiedIngredients(ingredients);
+
         final List<String> res = new java.util.ArrayList<>();
-        for (Ingredient ingredient : ingredients) {
+        for (Ingredient ingredient : simplifiedIngredients) {
             final String name = ingredient.getName();
             final float value = ingredient.getAmount();
             final String unit = ingredient.getUnit();
             res.add(name + " - " + value + " " + unit);
+        }
+        return res;
+    }
+
+    /**
+     * Simplify the ingredients by adding the amounts of ingredients with the same name.
+     *
+     * @param ingredients The list of ingredients.
+     * @return The simplified list of ingredients.
+     */
+    List<Ingredient> simplifiedIngredients(List<IngredientWithConvertedUnits> ingredients) {
+        // Get ingredients with the same name and simplify
+        // We do this by creating a new list, and seing if a name is already in the list
+        final List<Ingredient> res = new ArrayList<>();
+        for (IngredientWithConvertedUnits ingredient : ingredients) {
+            // we need to check if this ingredient was converted successully
+            if (!ingredient.getConvertStatus()) {
+                boolean found = false;
+                for (Ingredient resIngredient : res) {
+                    if (resIngredient.getName().equals(ingredient.getName())) {
+                        // Here we assume the units are the same, which they should be
+                        resIngredient.setAmount(resIngredient.getAmount() + ingredient.getAmount());
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    // make sure we are returning the converted amount
+                    final Ingredient newIngredient = new CommonIngredient(ingredient.getName(),
+                            ingredient.getAmount(),
+                            ingredient.getUnit());
+                    res.add(newIngredient);
+                }
+            }
+            else {
+                boolean found = false;
+                for (Ingredient resIngredient : res) {
+                    if (resIngredient.getName().equals(ingredient.getName())) {
+                        // Here we assume the units are the same, which they should be
+                        resIngredient.setAmount(resIngredient.getAmount() + ingredient.getConvertedAmount());
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    // make sure we are returning the converted amount
+                    final Ingredient newIngredient = new CommonIngredient(ingredient.getName(),
+                            ingredient.getConvertedAmount(),
+                            ingredient.getConvertedUnit());
+                    res.add(newIngredient);
+                }
+            }
         }
         return res;
     }

--- a/src/main/java/use_case/grocery_list/GroceryListOutputBoundary.java
+++ b/src/main/java/use_case/grocery_list/GroceryListOutputBoundary.java
@@ -10,5 +10,6 @@ public interface GroceryListOutputBoundary {
      * Prepares the view to display an error message.
      * @param errorMessage The error message to display.
      */
+
     void prepareFailView(String errorMessage);
 }

--- a/src/test/java/data_access/grocery_list/GroceryListDataAccessObjectTest.java
+++ b/src/test/java/data_access/grocery_list/GroceryListDataAccessObjectTest.java
@@ -1,0 +1,45 @@
+package data_access.grocery_list;
+
+import entity.Measurable;
+import entity.Pair;
+import entity.grocery_list.IngredientWithConvertedUnits;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class GroceryListDataAccessObjectTest {
+
+    @Test
+    public void getAllIngredientsWithOneID() {
+        List<Integer> input = new ArrayList<>();
+        input.add(716429);
+        GroceryListDataAccessObject groceryListDataAccessObject = new GroceryListDataAccessObject();
+
+        List<IngredientWithConvertedUnits> res = groceryListDataAccessObject.getAllIngredients(input);
+        assert res.get(0).getName().equals("butter");
+    }
+
+    @Test
+    public void convertToStandardUnitsSuccess() {
+        GroceryListDataAccessObject groceryListDataAccessObject = new GroceryListDataAccessObject();
+        Pair<Measurable<Float>, Boolean> res = groceryListDataAccessObject.convertToStandardUnits("garlic", 2, "cloves");
+        Measurable<Float> measurablePart = res.getFirst();
+        boolean status = res.getSecond();
+        assertEquals(measurablePart.getNumber(), 10, 0.1);
+        assertEquals(measurablePart.getUnit(), "grams");
+        assertEquals(status, true);
+    }
+
+    @Test
+    public void convertToStandardUnitsFailure() {
+        // This is weird because the api still works when giving it nonsense.
+        GroceryListDataAccessObject groceryListDataAccessObject = new GroceryListDataAccessObject();
+        Pair<Measurable<Float>, Boolean> res = groceryListDataAccessObject.convertToStandardUnits("asdfasdfasfdsaf", 2, "asdasdasdasdasd");
+        Measurable<Float> measurablePart = res.getFirst();
+        boolean status = res.getSecond();
+        assertEquals(status, true);
+    }
+}

--- a/src/test/java/use_case/grocery_list/GroceryListInteractorTest.java
+++ b/src/test/java/use_case/grocery_list/GroceryListInteractorTest.java
@@ -1,0 +1,249 @@
+package use_case.grocery_list;
+
+import data_access.grocery_list.GroceryListDataAccessObject;
+import data_access.grocery_list.GroceryListException;
+import data_access.grocery_list.GroceryListInMemoryDataAccessObject;
+import entity.CommonIngredient;
+import entity.Ingredient;
+import entity.grocery_list.CommonIngredientWithConvertedUnits;
+import entity.grocery_list.IngredientWithConvertedUnits;
+import interface_adapter.ViewManagerModel;
+import interface_adapter.grocery_list.GroceryListPresenter;
+import interface_adapter.grocery_list.GroceryListViewModel;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import use_case.grocery_list.GroceryListInteractor;
+
+import static org.junit.Assert.*;
+
+public class GroceryListInteractorTest {
+    // setup real database interactor, view model, and view presenter
+    GroceryListDataAccessInterface dao = new GroceryListDataAccessObject();
+    GroceryListViewModel viewModel = new GroceryListViewModel();
+    ViewManagerModel viewManagerModel = new ViewManagerModel();
+    GroceryListOutputBoundary presenter = new GroceryListPresenter(viewModel, viewManagerModel);
+    GroceryListInteractor interactor = new GroceryListInteractor(dao, presenter);
+
+    @Test
+    public void executeWithFailView() {
+        // Setup custom interactor
+        List<IngredientWithConvertedUnits> ingredients = new ArrayList<>();
+        // the dao getAllIngredients will return a list with this ingredient
+        IngredientWithConvertedUnits i1 = new CommonIngredientWithConvertedUnits(
+                "name1", 1f, 1,
+                "random sourceUnit", "grams",
+                2f, true
+        );
+        ingredients.add(i1);
+        GroceryListDataAccessInterface dao = new GroceryListDataAccessInterface() {
+            @Override
+            public List<IngredientWithConvertedUnits> getAllIngredients(List<Integer> ids) {
+                return List.of();
+            }
+
+            @Override
+            public List<Integer> getAllRecipeIds() {
+                throw new GroceryListException("Failed to get recipe ids");
+            }
+        };
+
+        GroceryListOutputBoundary presenter = new GroceryListPresenter(viewModel, viewManagerModel) {
+            @Override
+            public void prepareSuccessView(GroceryListOutputData outputData) {
+                assertEquals(outputData.getGroceryList().get(0), "name1 - 2.0 grams");
+            }
+            @Override
+            public void prepareFailView(String error) {
+                assertEquals(error, "Failed to get recipe ids");
+            }
+        };
+        GroceryListInteractor interactor = new GroceryListInteractor(dao, presenter);
+        interactor.execute();
+    }
+
+    @Test
+    public void executeWithConvertedIngredients() {
+        // Setup custom interactor
+        List<IngredientWithConvertedUnits> ingredients = new ArrayList<>();
+        // the dao getAllIngredients will return a list with this ingredient
+        IngredientWithConvertedUnits i1 = new CommonIngredientWithConvertedUnits(
+                "name1", 1f, 1,
+                "random sourceUnit", "grams",
+                2f, true
+        );
+        ingredients.add(i1);
+        GroceryListDataAccessInterface dao = new GroceryListInMemoryDataAccessObject(ingredients);
+        GroceryListOutputBoundary presenter = new GroceryListPresenter(viewModel, viewManagerModel) {
+            @Override
+            public void prepareSuccessView(GroceryListOutputData outputData) {
+                assertEquals(outputData.getGroceryList().get(0), "name1 - 2.0 grams");
+            }
+        };
+        GroceryListInteractor interactor = new GroceryListInteractor(dao, presenter);
+        interactor.execute();
+    }
+    @Test
+    public void executeWithConvertedDuplicateConvertableIngredients() {
+        // Setup custom interactor
+        List<IngredientWithConvertedUnits> ingredients = new ArrayList<>();
+        // the dao getAllIngredients will return a list with this ingredient
+        IngredientWithConvertedUnits i1 = new CommonIngredientWithConvertedUnits(
+                "name1", 1f, 1,
+                "random sourceUnit", "grams",
+                2f, true
+        );
+        IngredientWithConvertedUnits i2 = new CommonIngredientWithConvertedUnits(
+                "name1", 1f, 1,
+                "random sourceUnit", "grams",
+                2f, true
+        );
+        ingredients.add(i1);
+        ingredients.add(i2);
+        GroceryListDataAccessInterface dao = new GroceryListInMemoryDataAccessObject(ingredients);
+        GroceryListOutputBoundary presenter = new GroceryListPresenter(viewModel, viewManagerModel) {
+            @Override
+            public void prepareSuccessView(GroceryListOutputData outputData) {
+                assertEquals(outputData.getGroceryList().get(0), "name1 - 4.0 grams");
+            }
+        };
+        GroceryListInteractor interactor = new GroceryListInteractor(dao, presenter);
+        interactor.execute();
+    }
+
+
+    @Test
+    public void executeWithUnconvertableIngredients() {
+        List<IngredientWithConvertedUnits> ingredients = new ArrayList<>();
+        // the dao getAllIngredients will return a list with this ingredient
+        // This ingredient cannot be converted to grams
+        IngredientWithConvertedUnits i1 = new CommonIngredientWithConvertedUnits(
+                "name1", 1f, 1,
+                "random sourceUnit", null,
+                0f, false
+        );
+        ingredients.add(i1);
+        GroceryListDataAccessInterface dao = new GroceryListInMemoryDataAccessObject(ingredients);
+        GroceryListOutputBoundary presenter = new GroceryListPresenter(viewModel, viewManagerModel) {
+            @Override
+            public void prepareSuccessView(GroceryListOutputData outputData) {
+                assertEquals(outputData.getGroceryList().get(0), "name1 - 1.0 random sourceUnit");
+            }
+        };
+        GroceryListInteractor interactor = new GroceryListInteractor(dao, presenter);
+        interactor.execute();
+    }
+
+    @Test
+    public void executeWithDuplicateUnconvertableIngredients() {
+        List<IngredientWithConvertedUnits> ingredients = new ArrayList<>();
+        // the dao getAllIngredients will return a list with this ingredient
+        // This ingredient cannot be converted to grams
+        IngredientWithConvertedUnits i1 = new CommonIngredientWithConvertedUnits(
+                "name1", 1f, 1,
+                "random sourceUnit", null,
+                0f, false
+        );
+        IngredientWithConvertedUnits i2 = new CommonIngredientWithConvertedUnits(
+                "name1", 1f, 1,
+                "random sourceUnit", null,
+                0f, false
+        );
+        ingredients.add(i1);
+        ingredients.add(i2);
+        GroceryListDataAccessInterface dao = new GroceryListInMemoryDataAccessObject(ingredients);
+        GroceryListOutputBoundary presenter = new GroceryListPresenter(viewModel, viewManagerModel) {
+            @Override
+            public void prepareSuccessView(GroceryListOutputData outputData) {
+                assertEquals(outputData.getGroceryList().get(0), "name1 - 2.0 random sourceUnit");
+            }
+        };
+        GroceryListInteractor interactor = new GroceryListInteractor(dao, presenter);
+        interactor.execute();
+    }
+
+    /**
+     * This one tests a longer list that expects to output 2 ingredients instead of 1
+     */
+    @Test
+    public void executeWithDuplicateUnconvertableIngredients2() {
+        List<IngredientWithConvertedUnits> ingredients = new ArrayList<>();
+        // the dao getAllIngredients will return a list with this ingredient
+        // This ingredient cannot be converted to grams
+        IngredientWithConvertedUnits i1 = new CommonIngredientWithConvertedUnits(
+                "name1", 1f, 1,
+                "random sourceUnit", null,
+                0f, false
+        );
+        IngredientWithConvertedUnits i2 = new CommonIngredientWithConvertedUnits(
+                "name1", 1f, 1,
+                "random sourceUnit", null,
+                0f, false
+        );
+        IngredientWithConvertedUnits i3 = new CommonIngredientWithConvertedUnits(
+                "name2", 1f, 1,
+                "random sourceUnit", null,
+                0f, false
+        );
+        ingredients.add(i1);
+        ingredients.add(i2);
+        ingredients.add(i3);
+        GroceryListDataAccessInterface dao = new GroceryListInMemoryDataAccessObject(ingredients);
+        GroceryListOutputBoundary presenter = new GroceryListPresenter(viewModel, viewManagerModel) {
+            @Override
+            public void prepareSuccessView(GroceryListOutputData outputData) {
+                assertEquals(outputData.getGroceryList().get(0), "name1 - 2.0 random sourceUnit");
+                assertEquals(outputData.getGroceryList().get(1), "name2 - 1.0 random sourceUnit");
+                assertEquals(outputData.getGroceryList().size(), 2);
+            }
+        };
+        GroceryListInteractor interactor = new GroceryListInteractor(dao, presenter);
+        interactor.execute();
+    }
+
+    @Test
+    public void ingredientsToStrings() {
+        // Test the ingredientsToStrings method.
+        IngredientWithConvertedUnits i1 = new CommonIngredientWithConvertedUnits(
+                "name1", 1f, 1,
+                "random sourceUnit", "grams",
+                2f, true
+        );
+        IngredientWithConvertedUnits i2 = new CommonIngredientWithConvertedUnits(
+                "name2", 1f, 1,
+                "random sourceUnit", "grams",
+                2f, true
+        );
+        List<IngredientWithConvertedUnits> input = List.of(i1, i2);
+        List<String> res = interactor.ingredientsToStrings(input);
+        assertEquals(res.get(0), "name1 - 2.0 grams");
+        assertEquals(res.get(1), "name2 - 2.0 grams");
+    }
+
+    @Test
+    public void simplifiedIngredientsWithDuplicates() {
+        // Test the simplifiedIngredients with ingredients that have duplicates.
+        IngredientWithConvertedUnits i1 = new CommonIngredientWithConvertedUnits(
+                "name1", 1f, 1,
+                "random sourceUnit", "grams",
+                1f, true
+                );
+        IngredientWithConvertedUnits i2 = new CommonIngredientWithConvertedUnits(
+                "name1", 1f, 1,
+                "random sourceUnit", "grams",
+                1f, true
+        );
+        IngredientWithConvertedUnits i3 = new CommonIngredientWithConvertedUnits(
+                "name2", 1f, 1,
+                "random sourceUnit", "grams",
+                1f, true
+        );
+        List<IngredientWithConvertedUnits> input = List.of(i1, i2, i3);
+        List<Ingredient> res = interactor.simplifiedIngredients(input);
+        // We expect i1 and i2 to be combined with value 4 grams.
+        assertEquals(res.size(), 2);
+    }
+}


### PR DESCRIPTION
# Overview
The grocery list use case now normalizes all units and removes duplicates ingredients. This means that all of the ingredients you see will be in grams. However to do this, I used the spoonacular api, and this required an api call for each ingredient. So if you k recipes each with n ingredients, then the total amount of api calls (for ingredients only) is k &times; n which is a lot.
### Why this change was necessary:
- Before this change, if there were two or more items that had the same name, then these would appear in the list twice, which is not ideal
- I wanted to simplify duplicate names, but to do this, the amount of the ingredients with the same name must be in the same unit
- Thus I had to convert all units to some standard, which was arbitrarily chosen to be grams.
### What changed
- InMemoryDataAccessObject created
- Test case for the grocery list use case was created and it has 100% code coverage on the use case layer
- Test case for the data access object (not required for marks).
- Created a Pair entity since java doesn't support tuples, and a pair is a data structure I needed
- Added setAmount and setUnit to Ingredient.java because I needed these features. This shouldn't affect other code.
- Created an extension of Ingredient called IngredientWithConvertedUnits that was specific to my use case, since I needed to convert units, and I wanted the old units and the converted units.
